### PR TITLE
on my linux box, its /usr/bin/docker, and its in the path

### DIFF
--- a/src/main/validator.ts
+++ b/src/main/validator.ts
@@ -12,7 +12,7 @@ import { logger } from './logger';
 const DOCKER_IMAGE =
   process.arch === 'arm64'
     ? 'nathanleclaire/solana:v1.9.2'
-    : 'solanalabs/solana:v1.9.2';
+    : 'solanalabs/solana:v1.9.11';
 let DOCKER_PATH = 'docker';
 if (process.platform === 'darwin') {
   DOCKER_PATH = '/usr/local/bin/docker';


### PR DESCRIPTION
this is a bare minimum PR

really, we need to do some detection, and have a user modifiable setting, cos its complicated

or ship nerdctl and dance :)

also need to work out what you do if there is a local validator running, but its not in a container, or not in _our_ special named container

mmm, and a way to add other validators.

oh, and we get a stacktrace when there's no docker found, and instead, we need to politely tell the user, or use some other way.