### PR TITLE
Update network connectivity on selection, and detect if the network becomes reachable/not

### DIFF
--- a/src/main/validator.ts
+++ b/src/main/validator.ts
@@ -1,6 +1,6 @@
 import * as sol from '@solana/web3.js';
 import {
-  Net,
+  NetStatus,
   ValidatorLogsRequest,
   ValidatorState,
   ValidatorStateRequest,
@@ -22,26 +22,24 @@ const validatorState = async (
   msg: ValidatorStateRequest
 ): Promise<ValidatorState> => {
   const { net } = msg;
+
   let solConn: sol.Connection;
 
   // Connect to cluster
   const ret = {
-    running: false,
+    status: NetStatus.Unknown,
   } as ValidatorState;
-  if (net !== Net.Localhost) {
-    ret.running = true;
-    return ret;
-  }
   try {
     solConn = new sol.Connection(netToURL(net));
     await solConn.getEpochInfo();
   } catch (error) {
     const err = error as NodeJS.ErrnoException;
     if (err.code === 'ECONNREFUSED') {
+      ret.status = NetStatus.Unavailable;
       return ret;
     }
   }
-  ret.running = true;
+  ret.status = NetStatus.Running;
   return ret;
 };
 

--- a/src/renderer/nav/Accounts.tsx
+++ b/src/renderer/nav/Accounts.tsx
@@ -23,6 +23,7 @@ import {
   ACCOUNTS_NONE_KEY,
   BASE58_PUBKEY_REGEX,
   Net,
+  NetStatus,
   WBAccount,
 } from 'types/types';
 
@@ -149,7 +150,7 @@ const Accounts = () => {
   }
 
   let display = <></>;
-  if (validator.running) {
+  if (validator.status === NetStatus.Running) {
     display = (
       <>
         <div className="col-auto">
@@ -161,9 +162,8 @@ const Accounts = () => {
               </span>
               <button
                 type="button"
-                className={`ms-2 btn rounded btn-block btn-sm no-box-shadow ${
-                  addBtnClicked ? 'btn-primary-darker' : 'btn-primary'
-                }`}
+                className={`ms-2 btn rounded btn-block btn-sm no-box-shadow ${addBtnClicked ? 'btn-primary-darker' : 'btn-primary'
+                  }`}
                 onMouseDown={(
                   e: React.MouseEvent<HTMLButtonElement, MouseEvent>
                 ): void => {
@@ -190,18 +190,16 @@ const Accounts = () => {
           <div>
             <ul className="nav">
               <li
-                className={`${
-                  selectedAccount
+                className={`${selectedAccount
                     ? 'border-bottom active'
                     : 'opacity-25 cursor-not-allowed'
-                } ms-3 me-3 pt-1 pb-1 border-3 nav-item text-secondary nav-link-tab`}
+                  } ms-3 me-3 pt-1 pb-1 border-3 nav-item text-secondary nav-link-tab`}
               >
                 <small>Account</small>
               </li>
               <li
-                className={`${
-                  selectedAccountInfo ? '' : 'border-bottom active'
-                } ms-3 me-3 pt-1 pb-1 border-3 cursor-pointer nav-item text-secondary nav-link-tab`}
+                className={`${selectedAccountInfo ? '' : 'border-bottom active'
+                  } ms-3 me-3 pt-1 pb-1 border-3 cursor-pointer nav-item text-secondary nav-link-tab`}
                 onClick={() => {
                   dispatch(accountsActions.setSelected(''));
                 }}

--- a/src/renderer/slices/mainSlice.ts
+++ b/src/renderer/slices/mainSlice.ts
@@ -9,14 +9,13 @@ import {
   TOAST_BOTTOM_OFFSET,
   ToastProps,
   Net,
+  NetStatus,
   ConfigState,
 } from 'types/types';
 
 const validatorState: ValidatorState = {
   net: Net.Localhost,
-  running: false,
-  waitingForRun: false,
-  loading: false,
+  status: NetStatus.Unknown,
 };
 
 const toastState: ToastState = {
@@ -48,14 +47,8 @@ export const validatorSlice = createSlice({
     setNet: (state, action: PayloadAction<Net>) => {
       state.net = action.payload;
     },
-    setRunning: (state, action: PayloadAction<boolean>) => {
-      state.running = action.payload;
-    },
-    setWaitingForRun: (state, action: PayloadAction<boolean>) => {
-      state.waitingForRun = action.payload;
-    },
-    setLoading: (state, action: PayloadAction<boolean>) => {
-      state.loading = action.payload;
+    setState: (state, action: PayloadAction<NetStatus>) => {
+      state.status = action.payload;
     },
   },
 });

--- a/src/types/types.tsx
+++ b/src/types/types.tsx
@@ -7,6 +7,12 @@ export enum Net {
   Test = 'testnet',
   MainnetBeta = 'mainnet-beta',
 }
+export enum NetStatus {
+  Unknown = 'unknown',
+  Running = 'running',
+  Unavailable = 'unavailable',
+  Starting = 'starting',
+}
 
 export const ACCOUNTS_NONE_KEY = 'none';
 export const RANDOMART_W_CH = 17;
@@ -153,9 +159,7 @@ export interface ChangeBatchSize {
 
 export interface ValidatorState {
   net: Net;
-  running: boolean;
-  waitingForRun: boolean;
-  loading: boolean;
+  status: NetStatus;
 }
 
 export interface AccountsState {


### PR DESCRIPTION
changing networks between working and not-working didn't change the validator.running state, so things didn't match up

it still doesn't notice a state change in the selected network, but at least switching networks means it gets updates,

* [x] detect currently selected network state change, and show it
* [x] make the state ternery - add an unknown - that you get until the first validator state message is returned.
