### PR TITLE
[nomergey] POC for local validator environment reproducibility feature 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/cryptoworkbench/solana-workbench/v2
+
+go 1.17
+
+require github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
+github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=

--- a/workval/main.go
+++ b/workval/main.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+
+	"github.com/mitchellh/go-homedir"
+)
+
+func main() {
+	home, err := homedir.Dir()
+	if err != nil {
+		panic(err)
+	}
+	workbenchDir := path.Join(home, ".solana-workbench")
+	valArgs := []string{"--reset", "--ledger", path.Join(workbenchDir, "test-ledger")}
+	valCmd := exec.Command("solana-test-validator", valArgs...)
+	accountFiles, err := ioutil.ReadDir(path.Join(workbenchDir, "db", "accounts"))
+	for _, accountFile := range accountFiles {
+		valArgs = append(valArgs, "--account", accountFile.Name())
+	}
+    if err != nil {
+        panic(err)
+    }
+	bpfPrograms, err := ioutil.ReadDir(path.Join(workbenchDir, "db", "programs"))
+	for _, bpfProgram := range bpfPrograms {
+		valArgs = append(valArgs, "--bpf-program", bpfProgram.Name())
+	}
+    if err != nil {
+        panic(err)
+    }
+	fmt.Println("solana-test-validator", strings.Join(valArgs, " "))
+	fmt.Println("")
+	valCmd.Stdout = os.Stdout
+	valCmd.Stderr = os.Stderr
+	valCmd.Run()
+}

--- a/workval/main.go
+++ b/workval/main.go
@@ -23,14 +23,14 @@ func main() {
 	for _, accountFile := range accountFiles {
 		valArgs = append(valArgs, "--account", accountFile.Name())
 	}
-    if err != nil {
+    if err != nil && !os.IsNotExist(err) {
         panic(err)
     }
 	bpfPrograms, err := ioutil.ReadDir(path.Join(workbenchDir, "db", "programs"))
 	for _, bpfProgram := range bpfPrograms {
 		valArgs = append(valArgs, "--bpf-program", bpfProgram.Name())
 	}
-    if err != nil {
+    if err != nil && !os.IsNotExist(err) {
         panic(err)
     }
 	fmt.Println("solana-test-validator", strings.Join(valArgs, " "))


### PR DESCRIPTION
I got sick of `test-ledger` ending up in every dir where I happened to want to invoke `solana-test-validator`, plus I have been thinking a lot about local validator state management + reproducibility so I wanted to make a pass at an idea.

`--bpf-program` doesn't work right at the moment cause it doesn't get the program ID correctly. That's going to be a bit annoying and makes me think we might want to do this in Rust to parse the program IDs out, or leverage `Anchor.toml` for this (though there are plenty of non-Anchor programs)