### PR TITLE
Nitpick some styles in the ported-to-web 

### DIFF
--- a/src/renderer/App.scss
+++ b/src/renderer/App.scss
@@ -10,108 +10,134 @@
 @import '~bootswatch/dist/lux/bootswatch';
 
 // TODO: When using lux bootswatch, the .navbar padding-top and padding-bottom is too massive
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+th,
+.navbar,
+.btn {
+  text-transform: none;
+  box-shadow: none !important;
+}
+
 .navbar {
-    padding-top: .5rem;
-    padding-bottom: .5rem;
+  padding-top: 0rem;
+  padding-bottom: 0rem;
+}
+
+.btn {
+  border-radius: 1rem;
+  margin: 5px;
+  font-size: 1rem;
+  &-sm {
+      font-size: 0.8rem;
+      border-radius: 1rem;
+  }
 }
 
 :root {
-    --header-height: 3rem;
-    --nav-width: 68px;
-    --first-color: #4723D9;
-    --first-color-light: darkgray;
-    --white-color: lightgray;
-    --body-font: 'Nunito', sans-serif;
-    --normal-font-size: 1rem;
-    --z-fixed: 100;
+  --header-height: 3rem;
+  --nav-width: 68px;
+  --first-color: #4723d9;
+  --first-color-light: darkgray;
+  --white-color: lightgray;
+  --body-font: 'Nunito', sans-serif;
+  --normal-font-size: 1rem;
+  --z-fixed: 100;
 }
 
 .add-border {
-    border: 1px solid black;
+  border: 1px solid black;
 }
 
 .pageContent {
-    //background-color: lightblue;
-    position: fixed;
-    top: 60px;
-    left: 70px;
-    height: calc(100% - 130px);
-    padding-right: 100px;
-    scroll-behavior: auto;
-    overflow: scroll;
+  //background-color: lightblue;
+  position: fixed;
+  top: 60px;
+  left: 70px;
+  height: calc(100% - 130px);
+  padding-right: 100px;
+  scroll-behavior: auto;
+  overflow: scroll;
 }
 
 .almost-vh-100 {
-    height: 100%;
+  height: 100%;
 }
 .almost-vh-80 {
-    height: 80%;
-}.almost-vh-20 {
-    height: 20%;
+  height: 80%;
+}
+.almost-vh-20 {
+  height: 20%;
 }
 
 .l-navbar {
-    position: fixed;
-    top: 70px;
-    //left: -30%;
-    left: 0px;
-    //width: var(--nav-width);
-    width: 60px;
-    //height: 100vh;
-    //background-color: var(--first-color);
-    background-color: white !important; // TODO: figure this out
-    //padding: .5rem 1rem 0 0;
-    transition: .5s;
-    z-index: var(--z-fixed)
+  position: fixed;
+  top: 70px;
+  left: 0px;
+  width: 60px;
+  background-color: white !important; // TODO: figure this out
+  transition: 0.5s;
+  z-index: var(--z-fixed);
+  padding: 0rem 0rem;
 }
 
 .l-navbar .nav {
-    height: 100%;
-    display: flex;
-    flex-direction: column;
-    //justify-content: space-between;
-    overflow: hidden
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  column-gap: 0.2rem;
 }
 
 .l-navbar .nav_logo,
 .l-navbar .nav-link {
-    display: grid;
-    grid-template-columns: max-content max-content;
-    align-items: center;
-    column-gap: 1rem;
-    //padding: .5rem 0 .5rem 1.5rem
+  display: grid;
+  grid-template-columns: max-content max-content;
+  align-items: center;
+  margin-top: 1.5rem;
+  padding: 0rem 0rem 0rem 0.8rem;
 }
 
 .l-navbar .nav_logo {
-    margin-bottom: 2rem
+  margin-bottom: 2rem;
 }
 
 .l-navbar .nav_logo-icon {
-    font-size: 1.25rem;
-    color: var(--white-color)
+  font-size: 1.25rem;
+  color: var(--white-color);
 }
 
 .l-navbar .nav_logo-name {
-    color: var(--white-color);
-    font-weight: 700
+  color: var(--white-color);
+  font-weight: 700;
 }
 
 .l-navbar .nav-link {
-    position: relative;
-    color: var(--first-color-light);
-    margin-bottom: 1.5rem;
-    transition: .3s
+  position: relative;
+  color: var(--first-color-light);
+  margin-bottom: 1.5rem;
+  transition: 0.3s;
 }
 
 .l-navbar .nav-link:hover {
-    color: var(--white-color)
+  color: var(--white-color);
 }
 
 .l-navbar .nav_icon {
-    font-size: 1.25rem
+  font-size: 1.25rem;
 }
 
-
 .l-navbar .nav-link.active {
-    color: black;
+  color: black;
+}
+
+#l-navbar-dropdown {
+  margin: 0rem;
+  padding: 0rem;
+  border-radius: 0rem;
+  box-shadow: none;
 }

--- a/src/renderer/App.scss
+++ b/src/renderer/App.scss
@@ -78,7 +78,7 @@ th,
 
 .page-content {
   position: fixed;
-  top: 60px;
+  top: 25px;
   left: 70px;
   height: calc(100% - 130px);
   padding-right: 100px;

--- a/src/renderer/App.scss
+++ b/src/renderer/App.scss
@@ -88,6 +88,10 @@ th,
 
 .icon {
   &-interactive {
+    // next two lines copied from bootstrap
+    // p-1 and rounded classes
+    border-radius: 0.25rem !important;
+    padding: 0.25rem !important;
     &:hover {
       background-color: $gray-200;
     }

--- a/src/renderer/App.scss
+++ b/src/renderer/App.scss
@@ -9,7 +9,6 @@
 @import '~bootstrap/scss/bootstrap';
 @import '~bootswatch/dist/lux/bootswatch';
 
-// TODO: When using lux bootswatch, the .navbar padding-top and padding-bottom is too massive
 h1,
 h2,
 h3,
@@ -23,6 +22,7 @@ th,
   box-shadow: none !important;
 }
 
+// TODO: When using lux bootswatch, the .navbar padding-top and padding-bottom is too massive
 .navbar {
   padding-top: 0rem;
   padding-bottom: 0rem;
@@ -49,12 +49,7 @@ th,
   --z-fixed: 100;
 }
 
-.add-border {
-  border: 1px solid black;
-}
-
-.pageContent {
-  //background-color: lightblue;
+.page-content {
   position: fixed;
   top: 60px;
   left: 70px;

--- a/src/renderer/App.scss
+++ b/src/renderer/App.scss
@@ -9,6 +9,44 @@
 @import '~bootstrap/scss/bootstrap';
 @import '~bootswatch/dist/lux/bootswatch';
 
+$solgreen: #14f195;
+
+:root {
+  --header-height: 3rem;
+  --nav-width: 68px;
+  --first-color: #4723d9;
+  --first-color-light: darkgray;
+  --white-color: lightgray;
+  --body-font: 'Nunito', sans-serif;
+  --normal-font-size: 1rem;
+  --z-fixed: 100;
+}
+
+.text {
+  &-solgreen {
+      color: $solgreen;
+  }
+}
+
+@mixin inline-code() {
+  font-family: $font-family-code;
+  padding: 0.2em 0.4em;
+  border-radius: 6px;
+  background-color: $gray-200;
+  font-weight: 500;
+  color: $body-color;
+  border: 1px solid $gray-400;
+}
+
+code {
+  @include inline-code;
+}
+
+pre code {
+  background-color: $white;
+  border: none;
+}
+
 h1,
 h2,
 h3,
@@ -38,17 +76,6 @@ th,
   }
 }
 
-:root {
-  --header-height: 3rem;
-  --nav-width: 68px;
-  --first-color: #4723d9;
-  --first-color-light: darkgray;
-  --white-color: lightgray;
-  --body-font: 'Nunito', sans-serif;
-  --normal-font-size: 1rem;
-  --z-fixed: 100;
-}
-
 .page-content {
   position: fixed;
   top: 60px;
@@ -57,6 +84,15 @@ th,
   padding-right: 100px;
   scroll-behavior: auto;
   overflow: scroll;
+}
+
+.icon {
+  &-interactive {
+    &:hover {
+      background-color: $gray-200;
+    }
+    cursor: pointer;
+  }
 }
 
 .almost-vh-100 {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -248,7 +248,7 @@ function GlobalContainer() {
     <div className="vh-100">
       <Topbar />
       <Sidebar />
-      <Container fluid className="pageContent mt-3">
+      <Container fluid className="page-content mt-3">
         <Outlet />
       </Container>
     </div>

--- a/src/renderer/components/CopyIcon.tsx
+++ b/src/renderer/components/CopyIcon.tsx
@@ -1,6 +1,6 @@
 import { faCopy } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { OverlayTrigger, Tooltip } from 'react-bootstrap';
 
 function CopyIcon(props: { writeValue: string }) {

--- a/src/renderer/components/CopyIcon.tsx
+++ b/src/renderer/components/CopyIcon.tsx
@@ -36,7 +36,7 @@ function CopyIcon(props: { writeValue: string }) {
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
           _
         ) => window.setTimeout(() => setCopyTooltipText('Copy'), 500)}
-        className="p-1 icon icon-interactive rounded ms-1"
+        className="icon-interactive ms-1"
       >
         <FontAwesomeIcon className="cursor-pointer" icon={faCopy} />
       </span>

--- a/src/renderer/components/CopyIcon.tsx
+++ b/src/renderer/components/CopyIcon.tsx
@@ -26,23 +26,19 @@ function CopyIcon(props: { writeValue: string }) {
       delay={{ show: 250, hide: 0 }}
       overlay={renderCopyTooltip('rootKey')}
     >
-      <span className="p-1 icon rounded">
-        <FontAwesomeIcon
-          className="cursor-pointer"
-          icon={faCopy}
-          onClick={(
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            e: React.MouseEvent<SVGSVGElement, MouseEvent>
-          ) => {
-            e.stopPropagation();
-            setCopyTooltipText('Copied!');
-            navigator.clipboard.writeText(writeValue);
-          }}
-          onMouseLeave={(
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            _: React.MouseEvent<SVGSVGElement, MouseEvent> | undefined
-          ) => window.setTimeout(() => setCopyTooltipText('Copy'), 500)}
-        />
+      <span
+        onClick={(e) => {
+          e.stopPropagation();
+          setCopyTooltipText('Copied!');
+          navigator.clipboard.writeText(writeValue);
+        }}
+        onMouseLeave={(
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          _
+        ) => window.setTimeout(() => setCopyTooltipText('Copy'), 500)}
+        className="p-1 icon icon-interactive rounded ms-1"
+      >
+        <FontAwesomeIcon className="cursor-pointer" icon={faCopy} />
       </span>
     </OverlayTrigger>
   );

--- a/src/renderer/components/ProgramChange.tsx
+++ b/src/renderer/components/ProgramChange.tsx
@@ -60,10 +60,9 @@ export function ProgramChange(props: {
   return (
     <Container onClick={() => attemptAccountAdd(pubKey, false)}>
       <td onClick={() => pinAccount(pubKey, pinned)}>
-        <FontAwesomeIcon
-          className="me-1"
-          icon={pinned ? faStar : faRegular.faStar}
-        />
+        <span className="icon icon-interactive">
+          <FontAwesomeIcon icon={pinned ? faStar : faRegular.faStar} />
+        </span>
       </td>
 
       <td>

--- a/src/renderer/data/ValidatorNetwork/ValidatorNetwork.tsx
+++ b/src/renderer/data/ValidatorNetwork/ValidatorNetwork.tsx
@@ -84,7 +84,7 @@ function ValidatorNetwork() {
   return (
     <DropdownButton
       size="sm"
-      id="dropdown-basic-button"
+      id="l-navbar-dropdown"
       title={netDropdownTitle}
       onSelect={netDropdownSelect}
       className="ms-2 float-end"

--- a/src/renderer/data/ValidatorNetwork/ValidatorNetwork.tsx
+++ b/src/renderer/data/ValidatorNetwork/ValidatorNetwork.tsx
@@ -64,11 +64,11 @@ function ValidatorNetwork() {
   let statusClass = 'text-danger';
   if (validator.status === NetStatus.Running) {
     statusText = 'Available';
-    statusClass = 'text-success';
+    statusClass = 'text-solgreen';
   }
   const statusDisplay = (
     <span className="badge p-2">
-      <FontAwesomeIcon className={statusClass} icon={faCircle} />
+      <FontAwesomeIcon className={`me-1 ${statusClass}`} icon={faCircle} />
       {statusText}
     </span>
   );

--- a/src/renderer/nav/Account.tsx
+++ b/src/renderer/nav/Account.tsx
@@ -71,21 +71,21 @@ function Account() {
       </ButtonToolbar>
 
       <Row className="flex-fill">
-        <Col className="add-border">
+        <Col className="border">
           <ProgramChangeView attemptAccountAdd={attemptAccountAdd} />
         </Col>
-        <Col className="add-border">
+        <Col className="border">
           <Stack className=" almost-vh-100">
-            <Row className="add-border flex-fill">
+            <Row className="border flex-fill">
               <AccountView pubKey={selectedAccountInfo} />
             </Row>
-            <Row className="add-border flex-fill">
+            <Row className="border flex-fill">
               transaction or program details
             </Row>
           </Stack>
         </Col>
       </Row>
-      <Row className="add-border almost-vh-20">
+      <Row className="border almost-vh-20">
         ? console like thing - maybe this is where we emulate the solana/anchor
         cli?
         <LogView />


### PR DESCRIPTION
https://user-images.githubusercontent.com/1476820/162550503-97b1ca8b-5512-4972-833f-224f459b727d.mov

- Brought back solgreen for validator availability because flair
- Dropped box shadow on buttons cause even for modern web apps it doesn't seem conventional
- Pink code -> gray code (I find it much more palatable)
- Chill out the UPPER CASE in the UI which felt kind of yell-ey to me
- Bit of button consistency and prettification
- Introduce or bring back background-color on hover for interactive icon elements
- Simplify or clean up some class names, etc. (bootstrap has a border class for instance)
- Make top nav a bit less thick
- Format SCSS _somewhat_ (still a bit confused about how to configure correctly, will have to sync up there, but I don't think CI currently tests it)

btw, @SvenDowideit , you might be interested to know that this type of thing:

```
.almost-vh-100 {
  height: 100%;
}
.almost-vh-80 {
  height: 80%;
}
.almost-vh-20 {
  height: 20%;
}
```

can be written as nested SCSS:

```
.almost-vh {
  &-100 {
    height: 100%;
  }
  &-80 {
    height: 80%;
  }
  &-20 {
    height: 20%;
  }
}
```

which takes some getting used to but I find a bit cleaner and ends up being more sustainable when the rules and classes start to get more complicated (like how `.left-nav` has been evolving in the bottom of that file).

(that particular above construct could probably be reduced further to their cute little loop-over-map type features too, but ... eh)