### PR TITLE
Use table headers, add sort UX, and dramatically increase account cache for programChanges

### DIFF
--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -2,8 +2,8 @@ const { contextBridge, ipcRenderer } = require('electron');
 const log = require('electron-log');
 
 // TODO: make this a setting...
-log.transports.console.level = 'info';
-log.transports.ipc.level = 'debug';
+log.transports.console.level = 'silly';
+log.transports.ipc.level = 'silly';
 
 const send = (method, msg) => {
   ipcRenderer.send('main', method, msg);

--- a/src/renderer/components/AccountView.tsx
+++ b/src/renderer/components/AccountView.tsx
@@ -112,7 +112,7 @@ function AccountView(props: { pubKey: string | undefined }) {
                       <small className="text-muted">Executable</small>
                     </td>
                     <td>
-                      {account?.accountInfo.executable ? (
+                      {account?.accountInfo?.executable ? (
                         <div>
                           <FontAwesomeIcon
                             className="border-success rounded p-1 exe-icon"

--- a/src/renderer/components/ProgramChange.tsx
+++ b/src/renderer/components/ProgramChange.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState, useCallback } from 'react';
-import Container from 'react-bootstrap/Container';
 import { faStar } from '@fortawesome/free-solid-svg-icons';
 import * as faRegular from '@fortawesome/free-regular-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';

--- a/src/renderer/components/ProgramChange.tsx
+++ b/src/renderer/components/ProgramChange.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback } from 'react';
-
+import Container from 'react-bootstrap/Container';
 import { faStar } from '@fortawesome/free-solid-svg-icons';
 import * as faRegular from '@fortawesome/free-regular-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -9,7 +9,11 @@ import { useAppDispatch, useInterval, useAppSelector } from '../hooks';
 import InlinePK from './InlinePK';
 
 import { AccountInfo } from '../data/accounts/accountInfo';
-import { getAccount, truncateLamportAmount } from '../data/accounts/getAccount';
+import {
+  getAccount,
+  truncateLamportAmount,
+  truncateSolAmount,
+} from '../data/accounts/getAccount';
 import {
   Net,
   NetStatus,
@@ -56,18 +60,26 @@ export function ProgramChange(props: {
     updateAccount();
   }, 666);
 
-  const formatSolAmount = (amt: number): string => {
-    if (Math.abs(amt) < 0.01) {
-      return '<0.01';
-    }
-    return Math.abs(amt).toFixed(2);
-  };
+  // if (!change) {
+  //   return <Container key={pubKey}>Loading change for {pubKey}...</Container>;
+  // }
+  //
+  // return (
+  //   <tr key={pubKey} onClick={() => pinAccount(pubKey, false)}>
+  //     <td onClick={() => pinAccount(pubKey, pinned)}>
+  //       <FontAwesomeIcon
+  //         className="me-1"
+  //         icon={pinned ? faStar : faRegular.faStar}
+  //       />
+  //     </td>
+  //   </tr>
+  // );
 
   const showCount = change?.count || 0;
   const showSOL = change
     ? truncateLamportAmount(change)
     : `no account on ${net}`;
-  const showChange = change ? formatSolAmount(change.maxDelta) : 0;
+  const showChange = change ? truncateSolAmount(change.maxDelta) : 0;
 
   return (
     <tr
@@ -84,13 +96,11 @@ export function ProgramChange(props: {
       </td>
       <td>
         <span className="ms-2 rounded p-1">
-          <small className="text-secondary">Max Δ</small>
           <small className="ms-2">{showChange}</small>
         </span>
       </td>
       <td>
         <span className="ms-2 rounded p-1">
-          <small className="text-secondary">{change ? 'SOL' : ''}</small>
           <small className="ms-2">{showSOL}</small>
         </span>
       </td>

--- a/src/renderer/components/ProgramChange.tsx
+++ b/src/renderer/components/ProgramChange.tsx
@@ -60,21 +60,6 @@ export function ProgramChange(props: {
     updateAccount();
   }, 666);
 
-  // if (!change) {
-  //   return <Container key={pubKey}>Loading change for {pubKey}...</Container>;
-  // }
-  //
-  // return (
-  //   <tr key={pubKey} onClick={() => pinAccount(pubKey, false)}>
-  //     <td onClick={() => pinAccount(pubKey, pinned)}>
-  //       <FontAwesomeIcon
-  //         className="me-1"
-  //         icon={pinned ? faStar : faRegular.faStar}
-  //       />
-  //     </td>
-  //   </tr>
-  // );
-
   const showCount = change?.count || 0;
   const showSOL = change
     ? truncateLamportAmount(change)

--- a/src/renderer/components/ProgramChangeView.tsx
+++ b/src/renderer/components/ProgramChangeView.tsx
@@ -133,9 +133,11 @@ function ProgramChangeView() {
     if (status !== NetStatus.Running) {
       return () => {};
     }
+    setDisplayList([]);
     subscribeProgramChanges(net, programID, setValidatorSlot);
 
     return () => {
+      setDisplayList([]);
       unsubscribeProgramChanges(net, programID);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/renderer/components/ProgramChangeView.tsx
+++ b/src/renderer/components/ProgramChangeView.tsx
@@ -81,6 +81,22 @@ function ProgramChangeView() {
     pinnedAccount[key] = true;
   });
 
+  function sortFunctionDUP(a: AccountInfo, b: AccountInfo) {
+    switch (sortColumn) {
+      case 4: // count
+        return b.count - a.count;
+      case 3: // SOL
+        if (!b.accountInfo || !a.accountInfo) {
+          return 0;
+        }
+        return b.accountInfo.lamports - a.accountInfo.lamports;
+      case 2: // Max Delta
+      default:
+        return Math.abs(b.maxDelta) - Math.abs(a.maxDelta);
+    }
+  }
+  changes.sort((a, b) => sortFunctionDUP(a, b));
+
   changes.forEach((c: AccountInfo) => {
     if (!(c.pubKey in pinnedAccount)) {
       displayList.push(c.pubKey);
@@ -99,15 +115,7 @@ function ProgramChangeView() {
       return () => {};
     }
     function sortFunction(a: AccountInfo, b: AccountInfo) {
-      switch (sortColumn) {
-        case 4: // count
-          return b.count - a.count;
-        case 3: // SOL
-          return b.accountInfo.lamports - a.accountInfo.lamports;
-        case 2: // Max Delta
-        default:
-          return Math.abs(b.maxDelta) - Math.abs(a.maxDelta);
-      }
+      return sortFunctionDUP(a, b);
     }
     subscribeProgramChanges(
       net,
@@ -315,7 +323,7 @@ function ProgramChangeView() {
                     icon={sortColumn === 3 ? faSortDesc : faUnsorted}
                   />
                 </th>
-                <th onClick={() => setSortColumn(4)}>
+                <th /* onClick={() => setSortColumn(4)} */>
                   Count{' '}
                   <FontAwesomeIcon
                     className="me-1"

--- a/src/renderer/components/ProgramChangeView.tsx
+++ b/src/renderer/components/ProgramChangeView.tsx
@@ -83,7 +83,7 @@ function ProgramChangeView() {
   const [validatorSlot, setValidatorSlot] = useState<number>(0);
   const [pinnedAccount, setPinnedAccount] = useState<PinnedAccountMap>({});
 
-  function sortFunctionDUP(a: AccountInfo, b: AccountInfo) {
+  function sortFunction(a: AccountInfo, b: AccountInfo) {
     switch (sortColumn) {
       case SortColumn.Count:
         return b.count - a.count;
@@ -113,7 +113,7 @@ function ProgramChangeView() {
     const changes = GetTopAccounts(
       net,
       MAX_PROGRAM_CHANGES_DISPLAYED,
-      sortFunctionDUP
+      sortFunction
     );
 
     // logger.info('GetTopAccounts', changes);

--- a/src/renderer/components/ProgramChangeView.tsx
+++ b/src/renderer/components/ProgramChangeView.tsx
@@ -71,6 +71,7 @@ function ProgramChangeView() {
   const [changes, setChangesState] = useState<AccountInfo[]>([]);
   // const [paused, setPausedState] = useState<boolean>(false);
   const [sortColumn, setSortColumn] = useState<number>(2);
+  const [validatorSlot, setValidatorSlot] = useState<number>(0);
 
   const displayList: string[] = []; // list of Keys
   const pinnedAccount: PinnedAccountMap = {};
@@ -108,7 +109,13 @@ function ProgramChangeView() {
           return Math.abs(b.maxDelta) - Math.abs(a.maxDelta);
       }
     }
-    subscribeProgramChanges(net, programID, setChangesState, sortFunction);
+    subscribeProgramChanges(
+      net,
+      programID,
+      setChangesState,
+      sortFunction,
+      setValidatorSlot
+    );
 
     return () => {
       unsubscribeProgramChanges(net, programID);
@@ -129,6 +136,12 @@ function ProgramChangeView() {
   return (
     <div>
       <div className="mb-2">
+        <div className="mb-2">
+          <small>
+            <strong>Program Account Changes</strong>:
+            <small>(Validator Slot {validatorSlot})</small>
+          </small>
+        </div>
         <ButtonToolbar aria-label="Toolbar with button groups">
           <ButtonGroup size="sm" className="me-2" aria-label="First group">
             <Dropdown>
@@ -192,7 +205,9 @@ function ProgramChangeView() {
                           subscribeProgramChanges(
                             net,
                             programID,
-                            setChangesState
+                            setChangesState,
+                            undefined,
+                            setValidatorSlot
                           );
                           setProgramID(pastedID);
                         } else {

--- a/src/renderer/components/ProgramChangeView.tsx
+++ b/src/renderer/components/ProgramChangeView.tsx
@@ -44,8 +44,6 @@ import {
 import createNewAccount from '../data/accounts/account';
 import WatchAccountButton from './WatchAccountButton';
 
-const logger = window.electron.log;
-
 export const MAX_PROGRAM_CHANGES_DISPLAYED = 20;
 export enum KnownProgramID {
   SystemProgram = '11111111111111111111111111111111',
@@ -73,22 +71,28 @@ function ProgramChangeView() {
     }
   };
 
+  enum SortColumn {
+    Count,
+    Sol,
+    MaxDelta,
+  }
+
   const [displayList, setDisplayList] = useState<string[]>([]);
   // const [paused, setPausedState] = useState<boolean>(false);
-  const [sortColumn, setSortColumn] = useState<number>(2);
+  const [sortColumn, setSortColumn] = useState<SortColumn>(SortColumn.MaxDelta);
   const [validatorSlot, setValidatorSlot] = useState<number>(0);
   const [pinnedAccount, setPinnedAccount] = useState<PinnedAccountMap>({});
 
   function sortFunctionDUP(a: AccountInfo, b: AccountInfo) {
     switch (sortColumn) {
-      case 4: // count
+      case SortColumn.Count:
         return b.count - a.count;
-      case 3: // SOL
+      case SortColumn.Sol:
         if (!b.accountInfo || !a.accountInfo) {
           return 0;
         }
         return b.accountInfo.lamports - a.accountInfo.lamports;
-      case 2: // Max Delta
+      case SortColumn.MaxDelta:
       default:
         return Math.abs(b.maxDelta) - Math.abs(a.maxDelta);
     }
@@ -320,25 +324,33 @@ function ProgramChangeView() {
                   <FontAwesomeIcon className="me-1" icon={faRegular.faStar} />
                 </th>
                 <th>Address</th>
-                <th onClick={() => setSortColumn(2)}>
+                <th onClick={() => setSortColumn(SortColumn.MaxDelta)}>
                   Max Δ{' '}
                   <FontAwesomeIcon
                     className="me-1"
-                    icon={sortColumn === 2 ? faSortDesc : faUnsorted}
+                    icon={
+                      sortColumn === SortColumn.MaxDelta
+                        ? faSortDesc
+                        : faUnsorted
+                    }
                   />
                 </th>
-                <th onClick={() => setSortColumn(3)}>
+                <th onClick={() => setSortColumn(SortColumn.Sol)}>
                   SOL{' '}
                   <FontAwesomeIcon
                     className="me-1"
-                    icon={sortColumn === 3 ? faSortDesc : faUnsorted}
+                    icon={
+                      sortColumn === SortColumn.Sol ? faSortDesc : faUnsorted
+                    }
                   />
                 </th>
-                <th onClick={() => setSortColumn(4)}>
+                <th onClick={() => setSortColumn(SortColumn.Count)}>
                   Count{' '}
                   <FontAwesomeIcon
                     className="me-1"
-                    icon={sortColumn === 4 ? faSortDesc : faUnsorted}
+                    icon={
+                      sortColumn === SortColumn.Count ? faSortDesc : faUnsorted
+                    }
                   />
                 </th>
               </tr>

--- a/src/renderer/components/ProgramChangeView.tsx
+++ b/src/renderer/components/ProgramChangeView.tsx
@@ -128,6 +128,7 @@ function ProgramChangeView() {
     return () => {
       unsubscribeProgramChanges(net, programID);
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [net, programID, status, sortColumn]);
 
   if (status !== NetStatus.Running) {

--- a/src/renderer/data/accounts/accountInfo.ts
+++ b/src/renderer/data/accounts/accountInfo.ts
@@ -7,7 +7,7 @@ export const ACCOUNTS_NONE_KEY = 'none';
 // TO store Net in the getAccount object, we also need to abstract that into a UID
 // An expanded sol.KeyedAccountInfo
 export interface AccountInfo {
-  accountInfo: sol.AccountInfo<Buffer>;
+  accountInfo: sol.AccountInfo<Buffer> | undefined;
   accountId: sol.PublicKey;
   pubKey: string;
   net?: Net;

--- a/src/renderer/data/accounts/accountInfo.ts
+++ b/src/renderer/data/accounts/accountInfo.ts
@@ -7,7 +7,7 @@ export const ACCOUNTS_NONE_KEY = 'none';
 // TO store Net in the getAccount object, we also need to abstract that into a UID
 // An expanded sol.KeyedAccountInfo
 export interface AccountInfo {
-  accountInfo: sol.AccountInfo<Buffer> | undefined;
+  accountInfo: sol.AccountInfo<Buffer> | null;
   accountId: sol.PublicKey;
   pubKey: string;
   net?: Net;

--- a/src/renderer/data/accounts/getAccount.ts
+++ b/src/renderer/data/accounts/getAccount.ts
@@ -18,13 +18,25 @@ const HEXDUMP_BYTES = 512;
 //       Also use that to decide if we need to do a validator is available check or not - if we're watching changes, then we already know...
 
 const cache = new LRUCache<string, AccountInfo>({
-  maxSize: 100,
-  entryExpirationTimeInMS: 1000,
+  maxSize: 500,
+  entryExpirationTimeInMS: 60000,
 });
+
+export const getAllAccounts = (): AccountInfo[] => {
+  const list: AccountInfo[] = [];
+  for (const v of cache.values()) {
+    list.push(v);
+  }
+  return list;
+};
 
 export const updateCache = (account: AccountInfo) => {
   cache.set(`${account.net}_${account.pubKey}`, account);
 };
+
+export function peekAccount(net: Net, pubKey: string): AccountInfo | null {
+  return cache.peek(`${net}_${pubKey}`);
+}
 
 export async function getAccount(
   net: Net,

--- a/src/renderer/data/accounts/getAccount.ts
+++ b/src/renderer/data/accounts/getAccount.ts
@@ -145,10 +145,12 @@ export function GetTopAccounts(
   const keys: AccountInfo[] = [];
   // eslint-disable-next-line no-restricted-syntax
   for (const key of cache.keys()) {
-    // eslint-disable-next-line no-await-in-loop
-    const account = cache.peek(key);
-    if (account && account.accountInfo && account.accountInfo?.lamports > 0) {
-      keys.push(account);
+    if (key.startsWith(net)) {
+      // eslint-disable-next-line no-await-in-loop
+      const account = cache.peek(key);
+      if (account && account.accountInfo && account.accountInfo?.lamports > 0) {
+        keys.push(account);
+      }
     }
   }
   // logger.info('sorting cached accounts', keys.length);

--- a/src/renderer/data/accounts/getAccount.ts
+++ b/src/renderer/data/accounts/getAccount.ts
@@ -57,6 +57,7 @@ export async function getAccount(
   const solAccount = await solConn.getAccountInfo(key);
 
   logger.silly('getAccountInfo cache miss', pubKey, solAccount);
+  // TODO: these should not be made individually, instead, toss them on a list, and make getMultipleAccounts call once every 333mS or something
   //  if (solAccount) {
   const response: AccountInfo = {
     accountId: key,

--- a/src/renderer/data/accounts/getAccount.ts
+++ b/src/renderer/data/accounts/getAccount.ts
@@ -24,6 +24,7 @@ const cache = new LRUCache<string, AccountInfo>({
 
 export const getAllAccounts = (): AccountInfo[] => {
   const list: AccountInfo[] = [];
+  // eslint-disable-next-line no-restricted-syntax
   for (const v of cache.values()) {
     list.push(v);
   }

--- a/src/renderer/data/accounts/programChanges.ts
+++ b/src/renderer/data/accounts/programChanges.ts
@@ -67,11 +67,14 @@ export const subscribeProgramChanges = async (
         const account = peekAccount(net, pubKey);
         if (account) {
           ({ count, maxDelta } = account);
-          prevSolAmount = account.accountInfo.lamports / sol.LAMPORTS_PER_SOL;
-          solDelta = solAmount - prevSolAmount;
-          if (Math.abs(solDelta) > Math.abs(maxDelta)) {
-            maxDelta = solDelta;
+          if (account.accountInfo) {
+            prevSolAmount = account.accountInfo.lamports / sol.LAMPORTS_PER_SOL;
+            solDelta = solAmount - prevSolAmount;
+            if (Math.abs(solDelta) > Math.abs(maxDelta)) {
+              maxDelta = solDelta;
+            }
           }
+
           count += 1;
         } else {
           logger.silly('new pubKey in programChange', pubKey);

--- a/src/renderer/data/accounts/programChanges.ts
+++ b/src/renderer/data/accounts/programChanges.ts
@@ -37,7 +37,8 @@ export const subscribeProgramChanges = async (
   net: Net,
   programID: string,
   setChangesState: (accounts: AccountInfo[]) => void,
-  sortFunction: (a: AccountInfo, b: AccountInfo) => number
+  sortFunction: (a: AccountInfo, b: AccountInfo) => number,
+  setValidatorSlot: (slot: number) => void
 ) => {
   let programIDPubkey: sol.PublicKey;
   if (programID === sol.SystemProgram.programId.toString()) {
@@ -54,7 +55,10 @@ export const subscribeProgramChanges = async (
     const solConn = new sol.Connection(netToURL(net));
     const subscriptionID = solConn.onProgramAccountChange(
       programIDPubkey,
-      (info: sol.KeyedAccountInfo /* , ctx: sol.Context */) => {
+      (info: sol.KeyedAccountInfo, ctx: sol.Context) => {
+        if (setValidatorSlot) {
+          setValidatorSlot(ctx.slot);
+        }
         const pubKey = info.accountId.toString();
         logger.silly('programChange', pubKey);
         const solAmount = info.accountInfo.lamports / sol.LAMPORTS_PER_SOL;

--- a/src/renderer/data/accounts/programChanges.ts
+++ b/src/renderer/data/accounts/programChanges.ts
@@ -2,7 +2,7 @@ import * as sol from '@solana/web3.js';
 import { Net, netToURL } from '../ValidatorNetwork/validatorNetworkState';
 
 import { AccountInfo } from './accountInfo';
-import { peekAccount, getAllAccounts, updateCache } from './getAccount';
+import { peekAccount, updateCache } from './getAccount';
 
 const logger = window.electron.log;
 
@@ -11,15 +11,6 @@ export interface ProgramChangesState {
   paused: boolean;
 }
 
-export interface ChangeBatchSize {
-  [net: string]: number;
-}
-const PROGRAM_CHANGE_MAX_BATCH_SIZES: ChangeBatchSize = {
-  [Net.Localhost]: 1,
-  [Net.Dev]: 20,
-  [Net.Test]: 100,
-  [Net.MainnetBeta]: 500,
-};
 export interface ChangeLookupMap {
   [pubKey: string]: AccountInfo;
 }
@@ -36,8 +27,6 @@ const changeSubscriptions: ChangeSubscriptionMap = {};
 export const subscribeProgramChanges = async (
   net: Net,
   programID: string,
-  setChangesState: (accounts: AccountInfo[]) => void,
-  sortFunction: (a: AccountInfo, b: AccountInfo) => number,
   setValidatorSlot: (slot: number) => void
 ) => {
   let programIDPubkey: sol.PublicKey;
@@ -46,12 +35,13 @@ export const subscribeProgramChanges = async (
   } else {
     programIDPubkey = new sol.PublicKey(programID);
   }
-  let batchLen = 0;
 
   if (
     !(net in changeSubscriptions) ||
     !(programID in changeSubscriptions[net])
   ) {
+    logger.silly('subscribeProgramChanges', programID);
+
     const solConn = new sol.Connection(netToURL(net));
     const subscriptionID = solConn.onProgramAccountChange(
       programIDPubkey,
@@ -60,7 +50,7 @@ export const subscribeProgramChanges = async (
           setValidatorSlot(ctx.slot);
         }
         const pubKey = info.accountId.toString();
-        logger.silly('programChange', pubKey);
+        // logger.silly('programChange', pubKey);
         const solAmount = info.accountInfo.lamports / sol.LAMPORTS_PER_SOL;
         let [count, maxDelta, solDelta, prevSolAmount] = [1, 0, 0, 0];
 
@@ -77,7 +67,7 @@ export const subscribeProgramChanges = async (
 
           count += 1;
         } else {
-          logger.silly('new pubKey in programChange', pubKey);
+          // logger.silly('new pubKey in programChange', pubKey);
         }
 
         const programAccountChange: AccountInfo = {
@@ -91,21 +81,8 @@ export const subscribeProgramChanges = async (
           maxDelta,
           programID,
         };
-        batchLen += 1;
 
         updateCache(programAccountChange);
-
-        if (batchLen === PROGRAM_CHANGE_MAX_BATCH_SIZES[net]) {
-          const sortedChanges = getAllAccounts();
-          if (sortFunction) {
-            sortedChanges.sort((a, b) => sortFunction(a, b));
-          }
-
-          if (setChangesState) {
-            setChangesState(sortedChanges);
-          }
-          batchLen = 0;
-        }
       }
     );
     changeSubscriptions[net] = {
@@ -123,6 +100,8 @@ export const unsubscribeProgramChanges = async (
 ) => {
   const sub = changeSubscriptions[net][programID];
   if (!sub) return;
+  logger.silly('unsubscribeProgramChanges', programID);
+
   await sub.solConn.removeProgramAccountChangeListener(sub.subscriptionID);
   delete changeSubscriptions[net][programID];
 };


### PR DESCRIPTION
Its nice for the user to be able to select what we sort on:

![image](https://user-images.githubusercontent.com/28492/167324821-f7080ddd-4b7d-4130-9326-4ad8ce01828e.png)

This is also doing alot for #118 - it makes alot fewer uncached `getAccount()` requests