### PR TITLE
Fix/dont make requests when validator offline (and use electron-log in the renderer)

### DIFF
--- a/package.json
+++ b/package.json
@@ -245,7 +245,7 @@
     "bootstrap": "^5.1.3",
     "command-exists": "^1.2.9",
     "electron-debug": "^3.2.0",
-    "electron-log": "^4.4.4",
+    "electron-log": "^4.4.6",
     "electron-updater": "^4.6.4",
     "hexdump-nodejs": "^0.1.0",
     "history": "^5.2.0",

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -121,15 +121,12 @@ const installExtensions = async () => {
   const forceDownload = !!process.env.UPGRADE_EXTENSIONS;
   const extensions = ['REACT_DEVELOPER_TOOLS'];
 
-  return (
-    installer
-      .default(
-        extensions.map((name) => installer[name]),
-        forceDownload
-      )
-      /* eslint-disable no-console */
-      .catch(console.log)
-  );
+  return installer
+    .default(
+      extensions.map((name) => installer[name]),
+      forceDownload
+    )
+    .catch(log.info);
 };
 
 const createWindow = async () => {
@@ -205,4 +202,4 @@ app
       if (mainWindow === null) createWindow();
     });
   })
-  .catch(console.log);
+  .catch(log.catchErrors);

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -3,7 +3,7 @@ const log = require('electron-log');
 
 // TODO: make this a setting...
 log.transports.console.level = 'info';
-log.transports.ipc.level = 'info';
+log.transports.ipc.level = 'silly';
 
 const send = (method, msg) => {
   ipcRenderer.send('main', method, msg);

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -3,7 +3,7 @@ const log = require('electron-log');
 
 // TODO: make this a setting...
 log.transports.console.level = 'info';
-log.transports.ipc.level = 'silly';
+log.transports.ipc.level = 'debug';
 
 const send = (method, msg) => {
   ipcRenderer.send('main', method, msg);

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -1,10 +1,16 @@
 const { contextBridge, ipcRenderer } = require('electron');
+const log = require('electron-log');
+
+// TODO: make this a setting...
+log.transports.console.level = 'info';
+log.transports.ipc.level = 'info';
 
 const send = (method, msg) => {
   ipcRenderer.send('main', method, msg);
 };
 
 contextBridge.exposeInMainWorld('electron', {
+  log: log.functions,
   ipcRenderer: {
     runValidator() {
       send('run-validator', {});

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -260,6 +260,8 @@ function App() {
   const config = useAppSelector(selectConfigState);
   const dispatch = useAppDispatch();
 
+  Object.assign(console, window.electron.log.functions);
+
   useEffect(() => {
     const listener = (resp: any) => {
       const { method, res } = resp;

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -41,6 +41,8 @@ import {
 } from './data/Config/configState';
 import ValidatorNetwork from './data/ValidatorNetwork/ValidatorNetwork';
 
+const logger = window.electron.log;
+
 // So we can electron
 declare global {
   interface Window {
@@ -260,7 +262,7 @@ function App() {
   const config = useAppSelector(selectConfigState);
   const dispatch = useAppDispatch();
 
-  Object.assign(console, window.electron.log.functions);
+  Object.assign(console, logger.functions);
 
   useEffect(() => {
     const listener = (resp: any) => {

--- a/src/renderer/common/analytics.ts
+++ b/src/renderer/common/analytics.ts
@@ -19,8 +19,7 @@ const analytics = (event: string, metadata: any) => {
         amplitude.getInstance().logEvent(event, metadata);
       }
     } else {
-      // eslint-disable-next-line no-console
-      console.log('analytics event', event);
+      window.electron.log.info('analytics event', event);
     }
   }
 };

--- a/src/renderer/common/analytics.ts
+++ b/src/renderer/common/analytics.ts
@@ -4,6 +4,7 @@ import { ConfigKey } from '../data/Config/configState';
 
 const AMPLITUDE_KEY = 'f1cde3642f7e0f483afbb7ac15ae8277';
 const AMPLITUDE_HEARTBEAT_INTERVAL = 3600000;
+const logger = window.electron.log;
 
 amplitude.getInstance().init(AMPLITUDE_KEY);
 
@@ -19,7 +20,7 @@ const analytics = (event: string, metadata: any) => {
         amplitude.getInstance().logEvent(event, metadata);
       }
     } else {
-      window.electron.log.info('analytics event', event);
+      logger.info('analytics event', event);
     }
   }
 };

--- a/src/renderer/components/AccountView.tsx
+++ b/src/renderer/components/AccountView.tsx
@@ -16,6 +16,7 @@ import {
 } from '../data/accounts/getAccount';
 import {
   Net,
+  NetStatus,
   netToURL,
   selectValidatorNetworkState,
 } from '../data/ValidatorNetwork/validatorNetworkState';
@@ -41,13 +42,16 @@ const explorerURL = (net: Net, address: string) => {
 
 function AccountView(props: { pubKey: string | undefined }) {
   const { pubKey } = props;
-  const { net } = useAppSelector(selectValidatorNetworkState);
+  const { net, status } = useAppSelector(selectValidatorNetworkState);
 
   const [account, setSelectedAccountInfo] = useState<AccountInfo | undefined>(
     undefined
   );
 
   useInterval(() => {
+    if (status !== NetStatus.Running) {
+      return;
+    }
     if (pubKey) {
       getAccount(net, pubKey)
         .then((a) => setSelectedAccountInfo(a))

--- a/src/renderer/components/AccountView.tsx
+++ b/src/renderer/components/AccountView.tsx
@@ -24,6 +24,8 @@ import InlinePK from './InlinePK';
 import TransferSolButton from './TransferSolButton';
 import AirDropSolButton from './AirDropSolButton';
 
+const logger = window.electron.log;
+
 const explorerURL = (net: Net, address: string) => {
   switch (net) {
     case Net.Test:
@@ -49,7 +51,7 @@ function AccountView(props: { pubKey: string | undefined }) {
     if (pubKey) {
       getAccount(net, pubKey)
         .then((a) => setSelectedAccountInfo(a))
-        .catch(window.electron.log.info);
+        .catch(logger.info);
     } else {
       setSelectedAccountInfo(undefined);
     }

--- a/src/renderer/components/AccountView.tsx
+++ b/src/renderer/components/AccountView.tsx
@@ -49,8 +49,7 @@ function AccountView(props: { pubKey: string | undefined }) {
     if (pubKey) {
       getAccount(net, pubKey)
         .then((a) => setSelectedAccountInfo(a))
-        /* eslint-disable no-console */
-        .catch(console.log);
+        .catch(window.electron.log.info);
     } else {
       setSelectedAccountInfo(undefined);
     }

--- a/src/renderer/components/LogView.tsx
+++ b/src/renderer/components/LogView.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import * as sol from '@solana/web3.js';
 import { useAppSelector } from '../hooks';
 import {
+  NetStatus,
   netToURL,
   selectValidatorNetworkState,
 } from '../data/ValidatorNetwork/validatorNetworkState';
@@ -24,10 +25,14 @@ const logSubscriptions: LogSubscriptionMap = {};
 
 function LogView() {
   const [logs, setLogs] = useState<string[]>([]);
-  const { net } = useAppSelector(selectValidatorNetworkState);
+  const { net, status } = useAppSelector(selectValidatorNetworkState);
 
   useEffect(() => {
     setLogs([]);
+
+    if (status !== NetStatus.Running) {
+      return;
+    }
 
     const solConn = new sol.Connection(netToURL(net));
     const subscriptionID = solConn.onLogs(

--- a/src/renderer/components/LogView.tsx
+++ b/src/renderer/components/LogView.tsx
@@ -60,8 +60,7 @@ function LogView() {
         .then(() => {
           delete logSubscriptions[net];
         })
-        /* eslint-disable-next-line no-console */
-        .catch(console.log);
+        .catch(window.electron.log.info);
     };
   }, [net]);
 

--- a/src/renderer/components/LogView.tsx
+++ b/src/renderer/components/LogView.tsx
@@ -31,7 +31,7 @@ function LogView() {
     setLogs([]);
 
     if (status !== NetStatus.Running) {
-      return;
+      return () => {};
     }
 
     const solConn = new sol.Connection(netToURL(net));
@@ -68,7 +68,7 @@ function LogView() {
         })
         .catch(logger.info);
     };
-  }, [net]);
+  }, [net, status]);
 
   return (
     <div>

--- a/src/renderer/components/LogView.tsx
+++ b/src/renderer/components/LogView.tsx
@@ -23,8 +23,7 @@ const logSubscriptions: LogSubscriptionMap = {};
 
 function LogView() {
   const [logs, setLogs] = useState<string[]>([]);
-  const validator = useAppSelector(selectValidatorNetworkState);
-  const { net } = validator;
+  const { net } = useAppSelector(selectValidatorNetworkState);
 
   useEffect(() => {
     setLogs([]);

--- a/src/renderer/components/LogView.tsx
+++ b/src/renderer/components/LogView.tsx
@@ -12,6 +12,7 @@ export interface LogSubscriptionMap {
     solConn: sol.Connection;
   };
 }
+const logger = window.electron.log;
 
 // TODO: make this selectable - Return information at the selected commitment level
 //      [possible values: processed, confirmed, finalized]
@@ -60,7 +61,7 @@ function LogView() {
         .then(() => {
           delete logSubscriptions[net];
         })
-        .catch(window.electron.log.info);
+        .catch(logger.info);
     };
   }, [net]);
 

--- a/src/renderer/components/ProgramChange.tsx
+++ b/src/renderer/components/ProgramChange.tsx
@@ -32,8 +32,7 @@ export function ProgramChange(props: {
             setChangeInfo(res);
           }
         })
-        /* eslint-disable no-console */
-        .catch(console.log);
+        .catch(window.electron.log.info);
     } else {
       setChangeInfo(undefined);
     }

--- a/src/renderer/components/ProgramChange.tsx
+++ b/src/renderer/components/ProgramChange.tsx
@@ -4,13 +4,17 @@ import { faStar } from '@fortawesome/free-solid-svg-icons';
 import * as faRegular from '@fortawesome/free-regular-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { setSelected } from 'renderer/data/SelectedAccountsList/selectedAccountsState';
-import { useAppDispatch, useInterval } from '../hooks';
+import { useAppDispatch, useInterval, useAppSelector } from '../hooks';
 
 import InlinePK from './InlinePK';
 
 import { AccountInfo } from '../data/accounts/accountInfo';
 import { getAccount, truncateLamportAmount } from '../data/accounts/getAccount';
-import { Net } from '../data/ValidatorNetwork/validatorNetworkState';
+import {
+  Net,
+  NetStatus,
+  selectValidatorNetworkState,
+} from '../data/ValidatorNetwork/validatorNetworkState';
 
 const logger = window.electron.log;
 
@@ -24,8 +28,12 @@ export function ProgramChange(props: {
   const dispatch = useAppDispatch();
   const { pubKey, selected, net, pinned, pinAccount } = props;
   const [change, setChangeInfo] = useState<AccountInfo | undefined>(undefined);
+  const { status } = useAppSelector(selectValidatorNetworkState);
 
   const updateAccount = useCallback(() => {
+    if (status !== NetStatus.Running) {
+      return;
+    }
     if (pubKey) {
       getAccount(net, pubKey)
         .then((res) => {
@@ -38,7 +46,7 @@ export function ProgramChange(props: {
     } else {
       setChangeInfo(undefined);
     }
-  }, [net, pubKey]);
+  }, [net, status, pubKey]);
 
   useEffect(() => {
     updateAccount();

--- a/src/renderer/components/ProgramChange.tsx
+++ b/src/renderer/components/ProgramChange.tsx
@@ -12,6 +12,8 @@ import { AccountInfo } from '../data/accounts/accountInfo';
 import { getAccount, truncateLamportAmount } from '../data/accounts/getAccount';
 import { Net } from '../data/ValidatorNetwork/validatorNetworkState';
 
+const logger = window.electron.log;
+
 export function ProgramChange(props: {
   net: Net;
   pubKey: string;
@@ -32,7 +34,7 @@ export function ProgramChange(props: {
             setChangeInfo(res);
           }
         })
-        .catch(window.electron.log.info);
+        .catch(logger.info);
     } else {
       setChangeInfo(undefined);
     }

--- a/src/renderer/components/ProgramChangeView.tsx
+++ b/src/renderer/components/ProgramChangeView.tsx
@@ -56,8 +56,7 @@ function ProgramChangeView() {
             dispatch(accountsActions.unshift(res));
           }
         })
-        /* eslint-disable no-console */
-        .catch(console.log);
+        .catch(window.electron.log.info);
     } else {
       dispatch(accountsActions.rm(pubKey));
     }

--- a/src/renderer/components/ProgramChangeView.tsx
+++ b/src/renderer/components/ProgramChangeView.tsx
@@ -10,7 +10,10 @@ import { toast } from 'react-toastify';
 import OutsideClickHandler from 'react-outside-click-handler';
 
 import { useAppSelector, useAppDispatch } from '../hooks';
-import { selectValidatorNetworkState } from '../data/ValidatorNetwork/validatorNetworkState';
+import {
+  selectValidatorNetworkState,
+  NetStatus,
+} from '../data/ValidatorNetwork/validatorNetworkState';
 import { BASE58_PUBKEY_REGEX, getAccount } from '../data/accounts/getAccount';
 import { AccountInfo } from '../data/accounts/accountInfo';
 
@@ -38,7 +41,7 @@ interface PinnedAccountMap {
 
 function ProgramChangeView() {
   const dispatch = useAppDispatch();
-  const { net } = useAppSelector(selectValidatorNetworkState);
+  const { net, status } = useAppSelector(selectValidatorNetworkState);
 
   // TODO: I suspect It would be nicer to use a function need to try it..
   const selectAccounts = useAppSelector(selectAccountsListState);
@@ -82,12 +85,19 @@ function ProgramChangeView() {
   const [programID, setProgramID] = useState(KnownProgramID.SystemProgram);
 
   useEffect(() => {
+    if (status !== NetStatus.Running) {
+      return () => {};
+    }
     subscribeProgramChanges(net, programID, setChangesState);
 
     return () => {
       unsubscribeProgramChanges(net, programID);
     };
-  }, [net, programID]);
+  }, [net, programID, status]);
+
+  if (status !== NetStatus.Running) {
+    return <div>network not available</div>;
+  }
 
   const changeFilterDropdownTitle = (
     <>

--- a/src/renderer/components/ProgramChangeView.tsx
+++ b/src/renderer/components/ProgramChangeView.tsx
@@ -28,6 +28,8 @@ import {
   selectAccountsListState,
 } from '../data/SelectedAccountsList/selectedAccountsState';
 
+const logger = window.electron.log;
+
 export const MAX_PROGRAM_CHANGES_DISPLAYED = 20;
 export enum KnownProgramID {
   SystemProgram = '11111111111111111111111111111111',
@@ -56,7 +58,7 @@ function ProgramChangeView() {
             dispatch(accountsActions.unshift(res));
           }
         })
-        .catch(window.electron.log.info);
+        .catch(logger.info);
     } else {
       dispatch(accountsActions.rm(pubKey));
     }

--- a/src/renderer/data/ValidatorNetwork/ValidatorNetwork.tsx
+++ b/src/renderer/data/ValidatorNetwork/ValidatorNetwork.tsx
@@ -52,7 +52,9 @@ function ValidatorNetwork() {
       .then((state) => {
         return dispatch(setState(state));
       })
-      .catch(console.log);
+      .catch((err) => {
+        /* it would be nice to have a debug optional log for this */
+      });
   }, 5000);
 
   const netDropdownSelect = (eventKey: string | null) => {

--- a/src/renderer/data/ValidatorNetwork/ValidatorNetwork.tsx
+++ b/src/renderer/data/ValidatorNetwork/ValidatorNetwork.tsx
@@ -54,7 +54,7 @@ function ValidatorNetwork() {
         return dispatch(setState(state));
       })
       .catch((err) => {
-        /* it would be nice to have a debug optional log for this */
+        logger.debug(err);
       });
   }, 5000);
 

--- a/src/renderer/data/ValidatorNetwork/ValidatorNetwork.tsx
+++ b/src/renderer/data/ValidatorNetwork/ValidatorNetwork.tsx
@@ -17,6 +17,8 @@ import {
   selectValidatorNetworkState,
 } from './validatorNetworkState';
 
+const logger = window.electron.log;
+
 const validatorState = async (net: Net): Promise<NetStatus> => {
   let solConn: sol.Connection;
 
@@ -40,7 +42,7 @@ function ValidatorNetwork() {
       .then((state) => {
         return dispatch(setState(state));
       })
-      .catch(window.electron.log.info);
+      .catch(logger.info);
   }, [dispatch, net, validator]);
 
   const effect = () => {};

--- a/src/renderer/data/ValidatorNetwork/ValidatorNetwork.tsx
+++ b/src/renderer/data/ValidatorNetwork/ValidatorNetwork.tsx
@@ -40,8 +40,7 @@ function ValidatorNetwork() {
       .then((state) => {
         return dispatch(setState(state));
       })
-      /* eslint-disable no-console */
-      .catch(console.log);
+      .catch(window.electron.log.info);
   }, [dispatch, net, validator]);
 
   const effect = () => {};

--- a/src/renderer/data/accounts/account.ts
+++ b/src/renderer/data/accounts/account.ts
@@ -23,8 +23,7 @@ export async function transferSol(
   toKey: string,
   solAmount: string
 ) {
-  /* eslint-disable no-console */
-  console.log(
+  window.electron.log.info(
     `TODO(need to store private keys safely first): transfer ${solAmount} from ${fromKey} to ${toKey}`
   );
   return new Promise((resolve) => setTimeout(resolve, 2000));

--- a/src/renderer/data/accounts/account.ts
+++ b/src/renderer/data/accounts/account.ts
@@ -4,6 +4,8 @@ import * as web3 from '@solana/web3.js';
 
 import { Net, netToURL } from '../ValidatorNetwork/validatorNetworkState';
 
+const logger = window.electron.log;
+
 export async function airdropSol(net: Net, toKey: string, solAmount: string) {
   const to = new web3.PublicKey(toKey);
   const sols = parseFloat(solAmount);
@@ -23,7 +25,7 @@ export async function transferSol(
   toKey: string,
   solAmount: string
 ) {
-  window.electron.log.info(
+  logger.info(
     `TODO(need to store private keys safely first): transfer ${solAmount} from ${fromKey} to ${toKey}`
   );
   return new Promise((resolve) => setTimeout(resolve, 2000));

--- a/src/renderer/data/accounts/account.ts
+++ b/src/renderer/data/accounts/account.ts
@@ -35,7 +35,6 @@ async function createNewAccount(net: Net) {
   const keypair = web3.Keypair.generate();
   const payer = web3.Keypair.generate();
 
-  // web3.clusterApiUrl(net)
   const connection = new web3.Connection(netToURL(net));
 
   const airdropSignature = await connection.requestAirdrop(

--- a/src/renderer/data/accounts/getAccount.ts
+++ b/src/renderer/data/accounts/getAccount.ts
@@ -28,7 +28,7 @@ export async function getAccount(
   net: Net,
   pubKey: string
 ): Promise<AccountInfo | undefined> {
-  // logger.info("getAccount", {pubKey});
+  window.electron.log.silly('getAccount', { pubKey });
   const cachedResponse = cache.peek(`${net}_${pubKey}`);
   if (cachedResponse) {
     return cachedResponse;
@@ -38,7 +38,7 @@ export async function getAccount(
   const key = new sol.PublicKey(pubKey);
   const solAccount = await solConn.getAccountInfo(key);
 
-  // console.log('getAccountInfo cache miss', solAccount);
+  window.electron.log.silly('getAccountInfo cache miss', solAccount);
   if (solAccount) {
     const response: AccountInfo = {
       accountId: key,

--- a/src/renderer/data/accounts/getAccount.ts
+++ b/src/renderer/data/accounts/getAccount.ts
@@ -5,6 +5,8 @@ import { AccountInfo } from './accountInfo';
 
 import { Net, netToURL } from '../ValidatorNetwork/validatorNetworkState';
 
+const logger = window.electron.log;
+
 const hexdump = require('hexdump-nodejs');
 
 export const BASE58_PUBKEY_REGEX = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
@@ -28,7 +30,7 @@ export async function getAccount(
   net: Net,
   pubKey: string
 ): Promise<AccountInfo | undefined> {
-  window.electron.log.silly('getAccount', { pubKey });
+  logger.silly('getAccount', { pubKey });
   const cachedResponse = cache.peek(`${net}_${pubKey}`);
   if (cachedResponse) {
     return cachedResponse;
@@ -38,7 +40,7 @@ export async function getAccount(
   const key = new sol.PublicKey(pubKey);
   const solAccount = await solConn.getAccountInfo(key);
 
-  window.electron.log.silly('getAccountInfo cache miss', solAccount);
+  logger.silly('getAccountInfo cache miss', solAccount);
   if (solAccount) {
     const response: AccountInfo = {
       accountId: key,

--- a/src/renderer/data/accounts/programChanges.ts
+++ b/src/renderer/data/accounts/programChanges.ts
@@ -55,7 +55,7 @@ export const subscribeProgramChanges = async (
       programIDPubkey,
       (info: sol.KeyedAccountInfo /* , ctx: sol.Context */) => {
         const pubKey = info.accountId.toString();
-        // console.log('programChange', pubKey)
+        window.electron.log.silly('programChange', pubKey);
         const solAmount = info.accountInfo.lamports / sol.LAMPORTS_PER_SOL;
         let [count, maxDelta, solDelta, prevSolAmount] = [1, 0, 0, 0];
 
@@ -69,7 +69,7 @@ export const subscribeProgramChanges = async (
           }
           count += 1;
         } else {
-          // console.log('new pubKey in programChange', pubKey);
+          window.electron.log.silly('new pubKey in programChange', pubKey);
         }
 
         const programAccountChange: AccountInfo = {

--- a/src/renderer/data/accounts/programChanges.ts
+++ b/src/renderer/data/accounts/programChanges.ts
@@ -4,6 +4,8 @@ import { Net, netToURL } from '../ValidatorNetwork/validatorNetworkState';
 import { AccountInfo } from './accountInfo';
 import { updateCache } from './getAccount';
 
+const logger = window.electron.log;
+
 export interface ProgramChangesState {
   changes: AccountInfo[];
   paused: boolean;
@@ -55,7 +57,7 @@ export const subscribeProgramChanges = async (
       programIDPubkey,
       (info: sol.KeyedAccountInfo /* , ctx: sol.Context */) => {
         const pubKey = info.accountId.toString();
-        window.electron.log.silly('programChange', pubKey);
+        logger.silly('programChange', pubKey);
         const solAmount = info.accountInfo.lamports / sol.LAMPORTS_PER_SOL;
         let [count, maxDelta, solDelta, prevSolAmount] = [1, 0, 0, 0];
 
@@ -69,7 +71,7 @@ export const subscribeProgramChanges = async (
           }
           count += 1;
         } else {
-          window.electron.log.silly('new pubKey in programChange', pubKey);
+          logger.silly('new pubKey in programChange', pubKey);
         }
 
         const programAccountChange: AccountInfo = {

--- a/src/renderer/nav/Account.tsx
+++ b/src/renderer/nav/Account.tsx
@@ -14,8 +14,7 @@ import { selectAccountsListState } from '../data/SelectedAccountsList/selectedAc
 import createNewAccount from '../data/accounts/account';
 
 function Account() {
-  const validator = useAppSelector(selectValidatorNetworkState);
-  const { net } = validator;
+  const { net } = useAppSelector(selectValidatorNetworkState);
   const accounts = useAppSelector(selectAccountsListState);
   const { selectedAccount } = accounts;
 

--- a/src/renderer/nav/ValidatorNetworkInfo.tsx
+++ b/src/renderer/nav/ValidatorNetworkInfo.tsx
@@ -76,8 +76,7 @@ function ValidatorNetworkInfo() {
     // TODO: set a spinner while waiting for response
     fetchValidatorNetworkInfo(url)
       .then((d) => setData(d))
-      /* eslint-disable no-console */
-      .catch(console.log);
+      .catch(window.electron.log.info);
   }, [validator, url]);
 
   // TODO: maybe show te version spread as a histogram and feature info ala

--- a/src/renderer/nav/ValidatorNetworkInfo.tsx
+++ b/src/renderer/nav/ValidatorNetworkInfo.tsx
@@ -11,6 +11,8 @@ import {
   selectValidatorNetworkState,
 } from '../data/ValidatorNetwork/validatorNetworkState';
 
+const logger = window.electron.log;
+
 interface VersionCount {
   [key: string]: number;
 }
@@ -76,7 +78,7 @@ function ValidatorNetworkInfo() {
     // TODO: set a spinner while waiting for response
     fetchValidatorNetworkInfo(url)
       .then((d) => setData(d))
-      .catch(window.electron.log.info);
+      .catch(logger.info);
   }, [validator, url]);
 
   // TODO: maybe show te version spread as a histogram and feature info ala

--- a/src/types/types.tsx
+++ b/src/types/types.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import * as sol from '@solana/web3.js';
 
 export enum Net {


### PR DESCRIPTION
There's a bunch of ws and POST console logs that come from inside nested 4th party modules that show we're making requests even when we know there's no point

this gates them based on NetStatus, and replaces console.log with logger.info