### PR TITLE
Start validator if it exists and is functional

### DIFF
--- a/src/main/validator.ts
+++ b/src/main/validator.ts
@@ -59,7 +59,9 @@ const runValidator = async () => {
         --no-bpf-jit \
         --log`
     );
+    return;
   }
+  await execAsync(`${DOCKER_PATH} start solana-test-validator`);
 };
 
 const validatorLogs = async (msg: ValidatorLogsRequest) => {


### PR DESCRIPTION
Accidentally took this out and shouldn't have, gotta start the container if it's around and healthy