### PR TITLE
Improve create account ux

### DIFF
--- a/src/renderer/components/InlinePK.tsx
+++ b/src/renderer/components/InlinePK.tsx
@@ -2,10 +2,15 @@ import { ACCOUNTS_NONE_KEY } from '../data/accounts/accountInfo';
 
 import CopyIcon from './CopyIcon';
 
-const prettifyPubkey = (pk = '') =>
-  pk !== ACCOUNTS_NONE_KEY
+const prettifyPubkey = (pk = '') => {
+  if (pk === null) {
+    // cope with bad data in config
+    return '';
+  }
+  return pk !== ACCOUNTS_NONE_KEY
     ? `${pk.slice(0, 4)}…${pk.slice(pk.length - 4, pk.length)}`
     : '';
+};
 
 function InlinePK(props: { pk: string; className?: string }) {
   const { pk, className } = props;

--- a/src/renderer/components/ProgramChangeView.tsx
+++ b/src/renderer/components/ProgramChangeView.tsx
@@ -1,7 +1,7 @@
 import { faFilter, faSpinner } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useEffect, useRef, useState } from 'react';
-import { Dropdown, DropdownButton, Button, Col, Row } from 'react-bootstrap';
+import { Dropdown, DropdownButton, Button } from 'react-bootstrap';
 import ButtonGroup from 'react-bootstrap/ButtonGroup';
 import ButtonToolbar from 'react-bootstrap/ButtonToolbar';
 import Table from 'react-bootstrap/Table';
@@ -17,7 +17,7 @@ import {
   selectValidatorNetworkState,
   NetStatus,
 } from '../data/ValidatorNetwork/validatorNetworkState';
-import { BASE58_PUBKEY_REGEX, getAccount } from '../data/accounts/getAccount';
+import { BASE58_PUBKEY_REGEX } from '../data/accounts/getAccount';
 import { AccountInfo } from '../data/accounts/accountInfo';
 
 import Editable from './Editable';
@@ -222,7 +222,7 @@ function ProgramChangeView() {
                       value={`[${anchorEl?.secretKey.toString()}]`}
                     />
                     <b>
-                      NOTE: this account doesn't exist on chain until you
+                      NOTE: this account does not exist on chain until you
                       Airdrop of transfer SOL to it
                     </b>
                   </Popover.Body>

--- a/src/renderer/components/ProgramChangeView.tsx
+++ b/src/renderer/components/ProgramChangeView.tsx
@@ -12,6 +12,11 @@ import OutsideClickHandler from 'react-outside-click-handler';
 
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
 import { Keypair } from '@solana/web3.js';
+import {
+  setSelected,
+  accountsActions,
+  selectAccountsListState,
+} from 'renderer/data/SelectedAccountsList/selectedAccountsState';
 import { useAppSelector, useAppDispatch } from '../hooks';
 import {
   selectValidatorNetworkState,
@@ -26,10 +31,6 @@ import {
   unsubscribeProgramChanges,
   subscribeProgramChanges,
 } from '../data/accounts/programChanges';
-import {
-  accountsActions,
-  selectAccountsListState,
-} from '../data/SelectedAccountsList/selectedAccountsState';
 import createNewAccount from '../data/accounts/account';
 import WatchAccountButton from './WatchAccountButton';
 
@@ -233,7 +234,7 @@ function ProgramChangeView() {
                 onClick={() => {
                   const newAccount = createNewAccount();
                   pinAccount(newAccount.publicKey.toString(), false);
-                  // and now add a popup that tells the user to save the private key for later....
+                  dispatch(setSelected(newAccount.publicKey.toString()));
                   // or do we save it to the backend? and defer getting it back to 0.4.0..
                   setAnchorEl(newAccount);
                 }}

--- a/src/renderer/components/ProgramChangeView.tsx
+++ b/src/renderer/components/ProgramChangeView.tsx
@@ -213,9 +213,7 @@ function ProgramChangeView() {
                       </pre>
                     </div>
                     <div>
-                      Please save the Private key somewhere safe (can be saved
-                      to a new-id.json file that the solana commandline tool
-                      uses):
+                      Private key below. Keep it in a <pre>.json</pre> file somewhere safe.
                     </div>
                     <textarea
                       className="vscroll almost-vh-100 w-100"
@@ -223,8 +221,8 @@ function ProgramChangeView() {
                       value={`[${anchorEl?.secretKey.toString()}]`}
                     />
                     <b>
-                      NOTE: this account does not exist on chain until you
-                      Airdrop of transfer SOL to it
+                      NOTE: This account does not exist on chain until you
+                      Airdrop or transfer SOL to it.
                     </b>
                   </Popover.Body>
                 </Popover>

--- a/src/renderer/components/ProgramChangeView.tsx
+++ b/src/renderer/components/ProgramChangeView.tsx
@@ -31,8 +31,7 @@ import {
   selectAccountsListState,
 } from '../data/SelectedAccountsList/selectedAccountsState';
 import createNewAccount from '../data/accounts/account';
-
-const logger = window.electron.log;
+import WatchAccountButton from './WatchAccountButton';
 
 export const MAX_PROGRAM_CHANGES_DISPLAYED = 20;
 export enum KnownProgramID {
@@ -55,14 +54,7 @@ function ProgramChangeView() {
 
   const pinAccount = (pubKey: string, pinned: boolean) => {
     if (!pinned) {
-      getAccount(net, pubKey)
-        .then((res) => {
-          // eslint-disable-next-line promise/always-return
-          if (res) {
-            dispatch(accountsActions.unshift(res));
-          }
-        })
-        .catch(logger.info);
+      dispatch(accountsActions.unshift(pubKey));
     } else {
       dispatch(accountsActions.rm(pubKey));
     }

--- a/src/renderer/components/ProgramChangeView.tsx
+++ b/src/renderer/components/ProgramChangeView.tsx
@@ -1,7 +1,7 @@
 import { faFilter, faSpinner } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useEffect, useRef, useState } from 'react';
-import { Dropdown, DropdownButton } from 'react-bootstrap';
+import { Dropdown, DropdownButton, Button, Col, Row } from 'react-bootstrap';
 import ButtonGroup from 'react-bootstrap/ButtonGroup';
 import ButtonToolbar from 'react-bootstrap/ButtonToolbar';
 import Table from 'react-bootstrap/Table';
@@ -30,6 +30,7 @@ import {
   accountsActions,
   selectAccountsListState,
 } from '../data/SelectedAccountsList/selectedAccountsState';
+import createNewAccount from '../data/accounts/account';
 
 const logger = window.electron.log;
 
@@ -255,6 +256,7 @@ function ProgramChangeView() {
         <span>
           <small className="ms-2 text-secondary">
             <span>
+              Program:
               <code className="me-2">{programID}</code>
               {`${uniqueAccounts} account${uniqueAccounts > 1 ? 's' : ''}`}
             </span>

--- a/src/renderer/components/ProgramChangeView.tsx
+++ b/src/renderer/components/ProgramChangeView.tsx
@@ -6,9 +6,12 @@ import ButtonGroup from 'react-bootstrap/ButtonGroup';
 import ButtonToolbar from 'react-bootstrap/ButtonToolbar';
 import Table from 'react-bootstrap/Table';
 import { toast } from 'react-toastify';
+import Popover from 'react-bootstrap/Popover';
 
 import OutsideClickHandler from 'react-outside-click-handler';
 
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
+import { Keypair } from '@solana/web3.js';
 import { useAppSelector, useAppDispatch } from '../hooks';
 import {
   selectValidatorNetworkState,
@@ -84,6 +87,7 @@ function ProgramChangeView() {
   const filterProgramIDRef = useRef<HTMLInputElement>({} as HTMLInputElement);
 
   const [programID, setProgramID] = useState(KnownProgramID.SystemProgram);
+  const [anchorEl, setAnchorEl] = useState<Keypair | undefined>(undefined);
 
   useEffect(() => {
     if (status !== NetStatus.Running) {
@@ -188,6 +192,64 @@ function ProgramChangeView() {
                 </DropdownButton>
               </OutsideClickHandler>
             </Dropdown>
+          </ButtonGroup>
+          <ButtonGroup size="sm" className="me-2" aria-label="First group">
+            <OverlayTrigger
+              // trigger="click"
+              placement="right"
+              show={anchorEl !== undefined}
+              overlay={
+                <Popover className="mb-6" id="popover-basic">
+                  <Popover.Header as="h3">
+                    New Account
+                    <Button
+                      onClick={() => {
+                        setAnchorEl(undefined);
+                      }}
+                    >
+                      X
+                    </Button>
+                  </Popover.Header>
+                  <Popover.Body>
+                    <div>New Account Keypair created.</div>
+                    <div>
+                      Public Key:{' '}
+                      <pre>
+                        <code>{anchorEl?.publicKey.toString()}</code>
+                      </pre>
+                    </div>
+                    <div>
+                      Please save the Private key somewhere safe (can be saved
+                      to a new-id.json file that the solana commandline tool
+                      uses):
+                    </div>
+                    <textarea
+                      className="vscroll almost-vh-100 w-100"
+                      readOnly
+                      value={`[${anchorEl?.secretKey.toString()}]`}
+                    />
+                    <b>
+                      NOTE: this account doesn't exist on chain until you
+                      Airdrop of transfer SOL to it
+                    </b>
+                  </Popover.Body>
+                </Popover>
+              }
+            >
+              <Button
+                onClick={() => {
+                  const newAccount = createNewAccount();
+                  pinAccount(newAccount.publicKey.toString(), false);
+                  // and now add a popup that tells the user to save the private key for later....
+                  // or do we save it to the backend? and defer getting it back to 0.4.0..
+                  setAnchorEl(newAccount);
+                }}
+              >
+                Create Account
+              </Button>
+            </OverlayTrigger>
+
+            <WatchAccountButton pinAccount={pinAccount} />
           </ButtonGroup>
         </ButtonToolbar>
         <span>

--- a/src/renderer/components/WatchAccountButton.tsx
+++ b/src/renderer/components/WatchAccountButton.tsx
@@ -5,12 +5,6 @@ import Popover from 'react-bootstrap/Popover';
 import Button from 'react-bootstrap/Button';
 import Form from 'react-bootstrap/Form';
 import { Row, Col } from 'react-bootstrap';
-import { toast } from 'react-toastify';
-import { useAppSelector } from '../hooks';
-
-import { selectValidatorNetworkState } from '../data/ValidatorNetwork/validatorNetworkState';
-
-import { airdropSol } from '../data/accounts/account';
 
 function WatchAcountPopover(props: {
   pinAccount: (pk: string, b: boolean) => void;

--- a/src/renderer/components/WatchAccountButton.tsx
+++ b/src/renderer/components/WatchAccountButton.tsx
@@ -1,0 +1,86 @@
+import { useState, useEffect } from 'react';
+
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
+import Popover from 'react-bootstrap/Popover';
+import Button from 'react-bootstrap/Button';
+import Form from 'react-bootstrap/Form';
+import { Row, Col } from 'react-bootstrap';
+import { toast } from 'react-toastify';
+import { useAppSelector } from '../hooks';
+
+import { selectValidatorNetworkState } from '../data/ValidatorNetwork/validatorNetworkState';
+
+import { airdropSol } from '../data/accounts/account';
+
+function WatchAcountPopover(props: {
+  pinAccount: (pk: string, b: boolean) => void;
+}) {
+  const { pinAccount } = props;
+
+  const pubKeyVal = '';
+
+  const [toKey, setToKey] = useState<string>(pubKeyVal);
+
+  useEffect(() => {
+    if (pubKeyVal) {
+      setToKey(pubKeyVal);
+    }
+  }, [pubKeyVal]);
+
+  return (
+    <Popover id="popover-basic">
+      <Popover.Header as="h3">Airdrop SOL</Popover.Header>
+      <Popover.Body>
+        <Form>
+          <Form.Group as={Row} className="mb-8" controlId="formToAccount">
+            <Form.Label column sm={3}>
+              Public Key
+            </Form.Label>
+            <Col sm={9}>
+              <Form.Control
+                className="mb-6"
+                type="text"
+                placeholder="enter key"
+                value={toKey}
+                onChange={(e) => setToKey(e.target.value)}
+              />
+              <Form.Text className="text-muted" />
+            </Col>
+          </Form.Group>
+
+          <Form.Group as={Row} className="mb-3">
+            <Col sm={{ span: 10, offset: 2 }}>
+              <Button
+                type="button"
+                onClick={() => {
+                  pinAccount(toKey, false);
+                }}
+              >
+                Watch
+              </Button>
+            </Col>
+          </Form.Group>
+        </Form>
+      </Popover.Body>
+    </Popover>
+  );
+}
+
+function WatchAccountButton(props: {
+  pinAccount: (pk: string, b: boolean) => void;
+}) {
+  const { pinAccount } = props;
+
+  return (
+    <OverlayTrigger
+      trigger="click"
+      placement="bottom"
+      overlay={WatchAcountPopover({ pinAccount })}
+      rootClose
+    >
+      <Button variant="success">Watch</Button>
+    </OverlayTrigger>
+  );
+}
+
+export default WatchAccountButton;

--- a/src/renderer/data/SelectedAccountsList/selectedAccountsState.ts
+++ b/src/renderer/data/SelectedAccountsList/selectedAccountsState.ts
@@ -4,7 +4,6 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 // eslint-disable-next-line import/no-cycle
 import { RootState } from '../../store';
 import { loadState } from '../localstorage';
-import { AccountInfo } from '../accounts/accountInfo';
 
 export interface SelectedAccountsList {
   pinnedAccounts: string[]; // list of pubKeys (TODO: should really add net...)
@@ -59,8 +58,8 @@ export const selectedAccountsListSlice = createSlice({
     shift: (state) => {
       state.pinnedAccounts.shift();
     },
-    unshift: (state, action: PayloadAction<AccountInfo>) => {
-      state.pinnedAccounts.unshift(action.payload.pubKey);
+    unshift: (state, action: PayloadAction<string>) => {
+      state.pinnedAccounts.unshift(action.payload);
     },
     rm: (state, action: PayloadAction<string>) => {
       state.pinnedAccounts = state.pinnedAccounts.filter(

--- a/src/renderer/data/accounts/account.ts
+++ b/src/renderer/data/accounts/account.ts
@@ -31,7 +31,12 @@ export async function transferSol(
   return new Promise((resolve) => setTimeout(resolve, 2000));
 }
 
-async function createNewAccount(net: Net) {
+function createNewAccount() {
+  const keypair = web3.Keypair.generate();
+  return keypair;
+}
+
+async function createNewAccountWithMagic(net: Net) {
   const keypair = web3.Keypair.generate();
   const payer = web3.Keypair.generate();
 

--- a/src/renderer/data/accounts/account.ts
+++ b/src/renderer/data/accounts/account.ts
@@ -36,39 +36,4 @@ function createNewAccount() {
   return keypair;
 }
 
-async function createNewAccountWithMagic(net: Net) {
-  const keypair = web3.Keypair.generate();
-  const payer = web3.Keypair.generate();
-
-  const connection = new web3.Connection(netToURL(net));
-
-  const airdropSignature = await connection.requestAirdrop(
-    payer.publicKey,
-    web3.LAMPORTS_PER_SOL
-  );
-
-  await connection.confirmTransaction(airdropSignature);
-
-  const instructions = web3.SystemProgram.transfer({
-    fromPubkey: payer.publicKey,
-    toPubkey: keypair.publicKey,
-    lamports: web3.LAMPORTS_PER_SOL / 2,
-  });
-
-  const transaction = new web3.Transaction().add(instructions);
-
-  const signers = [
-    {
-      publicKey: payer.publicKey,
-      secretKey: payer.secretKey,
-    },
-  ];
-
-  /* const confirmation = */ await web3.sendAndConfirmTransaction(
-    connection,
-    transaction,
-    signers
-  );
-}
-
 export default createNewAccount;

--- a/src/renderer/data/accounts/account.ts
+++ b/src/renderer/data/accounts/account.ts
@@ -49,35 +49,6 @@ async function createNewAccountWithMagic(net: Net) {
 
   await connection.confirmTransaction(airdropSignature);
 
-  // const allocateTransaction = new web3.Transaction({
-  //     feePayer: payer.publicKey,
-  // })
-  // const keys = [
-  //     { pubkey: keypair.publicKey, isSigner: true, isWritable: true },
-  // ]
-  // const params = { space: 100 }
-
-  // const allocateStruct = {
-  //     index: 8,
-  //     layout: struct([u32('instruction'), ns64('space')]),
-  // }
-
-  // const data = Buffer.alloc(allocateStruct.layout.span)
-  // const layoutFields = { instruction: allocateStruct.index, ...params }
-  // allocateStruct.layout.encode(layoutFields, data)
-
-  // allocateTransaction.add(
-  //     new web3.TransactionInstruction({
-  //         keys,
-  //         programId: web3.SystemProgram.programId,
-  //         data,
-  //     })
-  // )
-
-  // await web3.sendAndConfirmTransaction(connection, allocateTransaction, [
-  //     payer,
-  //     keypair,
-  // ])
   const instructions = web3.SystemProgram.transfer({
     fromPubkey: payer.publicKey,
     toPubkey: keypair.publicKey,

--- a/src/renderer/nav/Account.tsx
+++ b/src/renderer/nav/Account.tsx
@@ -1,20 +1,13 @@
 import Stack from 'react-bootstrap/Stack';
-import { Button, Col, Row } from 'react-bootstrap';
-import ButtonGroup from 'react-bootstrap/ButtonGroup';
-import ButtonToolbar from 'react-bootstrap/ButtonToolbar';
-
-import { toast } from 'react-toastify';
+import { Col, Row } from 'react-bootstrap';
 
 import AccountView from '../components/AccountView';
 import ProgramChangeView from '../components/ProgramChangeView';
 import LogView from '../components/LogView';
 import { useAppSelector } from '../hooks';
-import { selectValidatorNetworkState } from '../data/ValidatorNetwork/validatorNetworkState';
 import { selectAccountsListState } from '../data/SelectedAccountsList/selectedAccountsState';
-import createNewAccount from '../data/accounts/account';
 
 function Account() {
-  const { net } = useAppSelector(selectValidatorNetworkState);
   const accounts = useAppSelector(selectAccountsListState);
   const { selectedAccount } = accounts;
 
@@ -23,26 +16,6 @@ function Account() {
     <Stack className="almost-vh-100">
       <Row className="flex-fill almost-vh-80">
         <Col className="col-md-6 almost-vh-100 vscroll">
-          <ButtonToolbar aria-label="Toolbar with button groups">
-            <ButtonGroup size="sm" className="me-2" aria-label="First group">
-              <div className="mb-2">
-                <strong>Program Account Changes</strong>
-              </div>
-            </ButtonGroup>
-            <ButtonGroup size="sm" className="me-2" aria-label="First group">
-              <Button
-                onClick={() => {
-                  toast.promise(createNewAccount(net), {
-                    pending: 'Account being created',
-                    success: 'Account created 👌',
-                    error: 'Account creation failed 🤯',
-                  });
-                }}
-              >
-                Create Account
-              </Button>
-            </ButtonGroup>
-          </ButtonToolbar>
           <ProgramChangeView />
         </Col>
         <Col className="border-left col-md-6 almost-vh-100 vscroll">


### PR DESCRIPTION
I don't want to re-do the safe to disk, generate key, and then wallet signing interaction for 0.3.0 - that will use some of the electron wallet code that is qued up for 0.4.0

but - this at least gives the user a chance to keep the private key

closes #104

![image](https://user-images.githubusercontent.com/28492/167094985-7727197e-5a7e-4e2e-8dcb-c449d5de03d0.png)
