### PR TITLE
DOESN'T WORK, but, show the imports that vite errors out on, even though they run

### DIFF
--- a/src/renderer/wallet-adapter/web3.ts
+++ b/src/renderer/wallet-adapter/web3.ts
@@ -1,10 +1,11 @@
 import * as sol from '@solana/web3.js';
 import * as splToken from '@solana/spl-token';
+import { createInitializeMintInstruction } from '@solana/spl-token/lib/types/instructions';
 import {
-  MINT_SIZE,
   getMinimumBalanceForRentExemptMint,
-  createInitializeMintInstruction,
-} from '@solana/spl-token';
+  MINT_SIZE,
+} from '@solana/spl-token/lib/types/state';
+
 import { WalletContextState } from '@solana/wallet-adapter-react';
 import { SendTransactionOptions } from '@solana/wallet-adapter-base';
 


### PR DESCRIPTION


@Bluskript this is a bunch of changes that vite and my IDE think are needed, but with them, we get a fatal run time error

without these changes, the code works at run time.

probably related to the 3 different vite run-time errors shown in the `npm run dev` cli (without this - using just `UX/tokens-rebase` )