### PR TITLE
Batch account cache updates into one call

### DIFF
--- a/src/renderer/components/AccountView.tsx
+++ b/src/renderer/components/AccountView.tsx
@@ -120,9 +120,7 @@ function AccountView(props: { pubKey: string | undefined }) {
       return;
     }
     if (pubKey) {
-      getAccount(net, pubKey)
-        .then((a) => setSelectedAccountInfo(a))
-        .catch(logger.info);
+      setSelectedAccountInfo(getAccount(net, pubKey));
     } else {
       setSelectedAccountInfo(undefined);
     }

--- a/src/renderer/components/ProgramChange.tsx
+++ b/src/renderer/components/ProgramChange.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useState } from 'react';
-import { logger } from '@/common/globals';
 import { setSelected } from '@/data/SelectedAccountsList/selectedAccountsState';
 import { AccountInfo } from '../data/accounts/accountInfo';
 import { useAccountMeta } from '../data/accounts/accountState';
@@ -33,27 +32,14 @@ export function ProgramChange(props: {
     if (status !== NetStatus.Running) {
       return;
     }
-    if (pubKey) {
-      getAccount(net, pubKey)
-        .then((res) => {
-          // eslint-disable-next-line promise/always-return
-          if (res) {
-            setChangeInfo(res);
-          }
-        })
-        .catch(logger.info);
-    } else {
+    if (!pubKey) {
       setChangeInfo(undefined);
+      return;
     }
+    setChangeInfo(getAccount(net, pubKey));
   }, [net, status, pubKey]);
-
-  useEffect(() => {
-    updateAccount();
-  }, [net, pubKey, updateAccount]);
-
-  useInterval(() => {
-    updateAccount();
-  }, 666);
+  useEffect(updateAccount, [updateAccount]);
+  useInterval(updateAccount, 666);
 
   const showCount = change?.count || 0;
   const showSOL = change
@@ -64,7 +50,7 @@ export function ProgramChange(props: {
   return (
     <tr
       onClick={() => dispatch(setSelected(pubKey))}
-      className={`transition duration-50 bg-opacity-20 hover:bg-opacity-30 hover:bg-primary-light ${
+      className={`transition cursor-pointer duration-50 bg-opacity-20 hover:bg-opacity-30 hover:bg-primary-light ${
         selected ? 'bg-primary-light' : ''
       }`}
     >

--- a/src/renderer/components/ProgramChangeView.tsx
+++ b/src/renderer/components/ProgramChangeView.tsx
@@ -15,7 +15,8 @@ import createNewAccount from '../data/accounts/account';
 import { AccountInfo } from '../data/accounts/accountInfo';
 import {
   BASE58_PUBKEY_REGEX,
-  GetTopAccounts,
+  getTopAccounts,
+  refreshAccountInfos,
 } from '../data/accounts/getAccount';
 import {
   subscribeProgramChanges,
@@ -120,13 +121,12 @@ function ProgramChangeView() {
       }
     });
 
-    const changes = GetTopAccounts(
+    const changes = getTopAccounts(
       net,
       MAX_PROGRAM_CHANGES_DISPLAYED,
       sortFunction
     );
 
-    // logger.info('GetTopAccounts', changes);
     changes.forEach((key: string) => {
       if (!(key in pinMap)) {
         showKeys.push(key);
@@ -134,6 +134,7 @@ function ProgramChangeView() {
     });
     setPinnedAccount(pinMap);
     setDisplayList(showKeys);
+    refreshAccountInfos(net, showKeys);
   }, 666);
 
   const uniqueAccounts = displayList.length;

--- a/src/renderer/data/accounts/accountInfo.ts
+++ b/src/renderer/data/accounts/accountInfo.ts
@@ -11,7 +11,6 @@ export interface AccountInfo {
   accountId: sol.PublicKey;
   pubKey: string;
   net?: Net;
-  decodedData: string;
   // updatedSlot: number // this should be used to update old account info
 
   // info from program Changes

--- a/src/renderer/data/accounts/getAccount.ts
+++ b/src/renderer/data/accounts/getAccount.ts
@@ -103,17 +103,6 @@ export const getHumanName = (meta: AccountMetaValues | undefined) => {
   return '';
 };
 
-export function getAccountNoWait(
-  net: Net,
-  pubKey: string
-): AccountInfo | undefined {
-  const cachedResponse = cache.peek(`${net}_${pubKey}`);
-  if (cachedResponse) {
-    return cachedResponse;
-  }
-  return undefined;
-}
-
 export async function refreshAccountInfos(net: Net, keys: string[]) {
   const solConn = new sol.Connection(netToURL(net));
   const pubKeys = keys.map((k) => new sol.PublicKey(k));
@@ -124,7 +113,6 @@ export async function refreshAccountInfos(net: Net, keys: string[]) {
       logger.silly('cache miss', `${net}_${keys[i]}`);
       return;
     }
-    logger.silly('cache hit', `${net}_${keys[i]}`);
     cachedAccount.accountInfo = info;
     cache.set(`${net}_${keys[i]}`, cachedAccount);
   });


### PR DESCRIPTION
Closes https://github.com/workbenchapp/solana-workbench/issues/118 

Instead of tons of `getAccountInfo` calls from the individual components, this PR rolls up the call to refresh top account info into just one `getMultipleAccountInfo()`

https://user-images.githubusercontent.com/1476820/177650621-ef52caaa-85fd-45d0-b00c-1b4f37ee7086.mov

Can haz no more highnet ban?