### PR TITLE
I trusted vscode's automagic use of '@/common' for the import, and clearly I shouldn't have

### DIFF
--- a/src/main/ipc/docker.ts
+++ b/src/main/ipc/docker.ts
@@ -9,8 +9,8 @@ import { execAsync } from '../const';
 
 import { logger } from '../logger';
 import { log } from '../validator';
-import { netToURL } from '@/common/strings';
-import { Net } from '@/types/types';
+import { netToURL } from '../../common/strings';
+import { Net } from '../../types/types';
 
 declare type IpcEvent = IpcRendererEvent & IpcMainEvent;
 


### PR DESCRIPTION


Signed-off-by: Sven Dowideit <SvenDowideit@home.org.au>