### PR TITLE
update cryptoworkbench/solana-amman tags to 1.10.30 and 1.11.2

### DIFF
--- a/src/main/ipc/docker.ts
+++ b/src/main/ipc/docker.ts
@@ -207,7 +207,7 @@ export function initDockerPromises() {
       // TODO: this would use something like https://github.com/jessestuart/docker-hub-utils
       // start with just ... curl https://hub.docker.com/v2/repositories/cryptoworkbench/solana-amman/tags/ | jq '.results[].name'
 
-      return ['v1.9.29', 'v1.10.27', 'v1.11.1'];
+      return ['v1.9.29', 'v1.10.30', 'v1.11.2'];
     }
   );
 


### PR DESCRIPTION
Signed-off-by: Sven Dowideit <SvenDowideit@home.org.au>