### PR TITLE
Make table rows compact

### DIFF
--- a/src/renderer/components/ProgramChangeView.tsx
+++ b/src/renderer/components/ProgramChangeView.tsx
@@ -190,7 +190,7 @@ function ProgramChangeView() {
   };
 
   return (
-    <div className="w-full p-3 flex flex-col overflow-auto">
+    <div>
       <div className="mb-2">
         <div className="mb-2 flex gap-2 items-center">
           <strong>Program Account Changes</strong>


### PR DESCRIPTION
The flexy rows feel a bit chaotic, this changes 'em back to 

@Bluskript am I overlooking anything about how this will affect layout etc.?

## before




<img width="1274" alt="Screen Shot 2022-07-12 at 3 09 38 PM" src="https://user-images.githubusercontent.com/1476820/178604080-6ddb8d84-c88e-4026-b9a0-f24f1afff1fc.png">

## after

<img width="1072" alt="Screen Shot 2022-07-12 at 3 08 08 PM" src="https://user-images.githubusercontent.com/1476820/178604086-34b2510d-6612-4e20-b978-1a9eb0b4fc82.png">