### PR TITLE
Fix a few UI nitpicks

### DIFF
--- a/src/renderer/components/AccountView.tsx
+++ b/src/renderer/components/AccountView.tsx
@@ -257,16 +257,18 @@ function AccountView(props: { pubKey: string | undefined }) {
           </tbody>
         </table>
       </div>
-      <div className="ms-1">
-        <div>
-          <small className="text-muted">Data</small>
+      {!accountMeta?.privatekey && (
+        <div className="ms-1">
+          <div>
+            <small className="text-muted">Data</small>
+          </div>
+          <div className="p-2">
+            <code className="whitespace-pre-wrap w-full block">
+              {decodedAccountData}
+            </code>
+          </div>
         </div>
-        <div className="p-2">
-          <code className="whitespace-pre-wrap w-full block">
-            {decodedAccountData}
-          </code>
-        </div>
-      </div>
+      )}
     </Container>
   );
 }

--- a/src/renderer/nav/Account.tsx
+++ b/src/renderer/nav/Account.tsx
@@ -26,9 +26,6 @@ function Account() {
         <div className="overflow-auto">
           <div className="flex-1 p-3">
             <AccountView pubKey={selectedAccount} />
-            <div className="border-top flex-fill">
-              transaction or program details
-            </div>
           </div>
         </div>
       </Split>


### PR DESCRIPTION
- If an account has a private key, it's implied it's a wallet or
  authority, so hide the data field
- Remove unused filler text