### PR TITLE
Pubkey validation added to WatchAccountPopover

### DIFF
--- a/src/renderer/components/ProgramChangeView.tsx
+++ b/src/renderer/components/ProgramChangeView.tsx
@@ -1,6 +1,7 @@
 import { faSpinner } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useWallet } from '@solana/wallet-adapter-react';
+import { PublicKey } from '@solana/web3.js';
 import { useEffect, useState } from 'react';
 import { Button } from 'react-bootstrap';
 import { toast } from 'react-toastify';
@@ -66,6 +67,14 @@ function ProgramChangeView() {
   const { pinnedAccounts } = selectAccounts;
 
   const pinAccount = (pubKey: string, pinned: boolean) => {
+    // validate public key
+    try {
+      PublicKey.isOnCurve(pubKey);
+    } catch (err) {
+      console.log(err);
+      return;
+    }
+
     if (!pinned) {
       dispatch(accountsActions.unshift(pubKey));
     } else {

--- a/src/renderer/components/WatchAccountButton.tsx
+++ b/src/renderer/components/WatchAccountButton.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { PublicKey } from '@solana/web3.js';
 import { Col, Row } from 'react-bootstrap';
 import Button from 'react-bootstrap/Button';
 import Form from 'react-bootstrap/Form';
@@ -13,12 +14,28 @@ function WatchAcountPopover(props: {
   const pubKeyVal = '';
 
   const [toKey, setToKey] = useState<string>(pubKeyVal);
+  const [validationError, setValidationErr] = useState('');
 
   useEffect(() => {
     if (pubKeyVal) {
       setToKey(pubKeyVal);
     }
   }, [pubKeyVal]);
+
+  useEffect(() => {
+    if (!toKey) {
+      setValidationErr('');
+      return;
+    }
+    // validate public key
+    try {
+      PublicKey.isOnCurve(toKey);
+      setValidationErr('');
+    } catch (err) {
+      setValidationErr('Invalid key');
+      console.log(err);
+    }
+  }, [toKey]);
 
   return (
     <Popover id="popover-basic">
@@ -31,12 +48,21 @@ function WatchAcountPopover(props: {
             </Form.Label>
             <Col sm={9}>
               <Form.Control
-                className="mb-6"
                 type="text"
                 placeholder="enter key"
                 value={toKey}
                 onChange={(e) => setToKey(e.target.value)}
               />
+              {validationError ? (
+                <Form.Control.Feedback
+                  type="invalid"
+                  className="text-red-400 text-xs"
+                >
+                  {validationError}
+                </Form.Control.Feedback>
+              ) : (
+                <></>
+              )}
               <Form.Text className="text-muted" />
             </Col>
           </Form.Group>
@@ -45,6 +71,7 @@ function WatchAcountPopover(props: {
             <Col sm={{ span: 10, offset: 2 }}>
               <Button
                 type="button"
+                disabled={!!validationError || !toKey}
                 onClick={() => {
                   pinAccount(toKey, false);
                 }}

--- a/src/renderer/components/WatchAccountButton.tsx
+++ b/src/renderer/components/WatchAccountButton.tsx
@@ -14,7 +14,7 @@ function WatchAcountPopover(props: {
   const pubKeyVal = '';
 
   const [toKey, setToKey] = useState<string>(pubKeyVal);
-  const [validationError, setValidationErr] = useState('');
+  const [validationError, setValidationErr] = useState<string | undefined>();
 
   useEffect(() => {
     if (pubKeyVal) {
@@ -30,7 +30,7 @@ function WatchAcountPopover(props: {
     // validate public key
     try {
       PublicKey.isOnCurve(toKey);
-      setValidationErr('');
+      setValidationErr(undefined);
     } catch (err) {
       setValidationErr('Invalid key');
       console.log(err);

--- a/src/renderer/components/WatchAccountButton.tsx
+++ b/src/renderer/components/WatchAccountButton.tsx
@@ -71,7 +71,7 @@ function WatchAcountPopover(props: {
             <Col sm={{ span: 10, offset: 2 }}>
               <Button
                 type="button"
-                disabled={!!validationError || !toKey}
+                disabled={validationError || !toKey}
                 onClick={() => {
                   pinAccount(toKey, false);
                 }}


### PR DESCRIPTION
Mistakeny added a invalid public key in `watchAccountPopover` which caused the entire app to break. 
![Screenshot from 2022-07-13 17-50-22](https://user-images.githubusercontent.com/51258872/178743566-9efd3173-5db4-45f3-a7de-7783cbd2c757.png)
I guess when I added the invalid address to watch, it got stored and is causing this issue even after I restart the app. Next, I will clear stored address from memory, and figure our any measures we can take if such address somehow gets stored. But, for now, this PR should prevent user from entering the invalid address.
