### PR TITLE
Hide data for wallets

### DIFF
--- a/src/renderer/components/AccountView.tsx
+++ b/src/renderer/components/AccountView.tsx
@@ -265,16 +265,18 @@ function AccountView(props: { pubKey: string | undefined }) {
               </table>
             </div>
           </div>
-          <div className="ms-1">
-            <div>
-              <small className="text-muted">Data :</small>
+          {!accountMeta?.privatekey && (
+            <div className="ms-1">
+              <div>
+                <small className="text-muted">Data :</small>
+              </div>
+              <div>
+                <pre className="exe-hexdump p-2 rounded">
+                  <code>{decodedAccountData}</code>
+                </pre>
+              </div>
             </div>
-            <div>
-              <pre className="exe-hexdump p-2 rounded">
-                <code>{decodedAccountData}</code>
-              </pre>
-            </div>
-          </div>
+          )}
 
           <div className="ms-1">
             <div>


### PR DESCRIPTION
If we know the private key for the wallet, it's most likely a "wallet" account, and contains no data.

Technically, we should probably hide decoded data for all accounts where it's empty regardless of if we know the key, but this is a quick patch that will get 80% of the way there.