### PR TITLE
Typescript: during initial rendering, mintPubKey can be undefined, so avoid passi…

### DIFF
--- a/src/renderer/components/tokens/MetaplexTokenData.tsx
+++ b/src/renderer/components/tokens/MetaplexTokenData.tsx
@@ -207,6 +207,10 @@ function MetaplexTokenDataButton(props: {
   const { mintPubKey, disabled } = props;
   const { status } = useAppSelector(selectValidatorNetworkState);
 
+  if (!mintPubKey) {
+    return <></>;
+  }
+
   return (
     <OverlayTrigger
       trigger="click"


### PR DESCRIPTION
…ng that on

for https://github.com/workbenchapp/solana-workbench/pull/241#issuecomment-1185733540 - https://github.com/workbenchapp/solana-workbench/pull/241#issuecomment-1186632658

Signed-off-by: Sven Dowideit <SvenDowideit@home.org.au>