### PR TITLE
Airdrop SOL automatically to wallets 

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -124,8 +124,8 @@ function Sidebar() {
 
 function Topbar() {
   const wallet = useWallet();
-  const { net } = useAppSelector(selectValidatorNetworkState);
   const validator = useAppSelector(selectValidatorNetworkState);
+  const { net } = validator;
 
   useEffect(() => {
     const airdropIfNeeded = async () => {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -246,7 +246,6 @@ export const GlobalContainer: FC = () => {
   const config = useConfigState();
   const accounts = useAccountsState();
   const { net } = useAppSelector(selectValidatorNetworkState);
-  const validator = useAppSelector(selectValidatorNetworkState);
 
   const wallets = useMemo(() => {
     const electronStorageWallet = new ElectronAppStorageWalletAdapter({
@@ -256,10 +255,10 @@ export const GlobalContainer: FC = () => {
             "Config not loaded, can't get ElectronWallet keypair yet"
           );
         }
+
         return getElectronStorageWallet(dispatch, config, accounts);
       },
     });
-
     return [
       // Sadly, electron apps don't run browser plugins, so these won't work without lots of pain
       // new PhantomWalletAdapter(),

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -130,7 +130,7 @@ function Topbar() {
   useEffect(() => {
     const airdropIfNeeded = async () => {
       if (validator.status !== NetStatus.Running) return;
-      let lamportAmount = 0;
+      let amount = 0;
 
       // arbitrary -- want to let people top up
       // on devnet SOL when they can
@@ -138,18 +138,18 @@ function Topbar() {
       switch (net) {
         case Net.Dev:
           // limit per devnet aidrop request
-          lamportAmount = 2;
+          amount = 2;
           break;
         case Net.Test:
           // limit per testnet airdrop request
-          lamportAmount = 1;
+          amount = 1;
           // arbitrary
           airdropThreshold = 5;
           break;
         case Net.MainnetBeta:
           return;
         default:
-          lamportAmount = 1000;
+          amount = 1000;
       }
       const solConn = new sol.Connection(netToURL(net));
       if (wallet.publicKey) {
@@ -158,7 +158,7 @@ function Topbar() {
           if (balance < airdropThreshold) {
             solConn.requestAirdrop(
               wallet.publicKey,
-              sol.LAMPORTS_PER_SOL * lamportAmount
+              sol.LAMPORTS_PER_SOL * amount
             );
           }
         } catch (e) {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -131,14 +131,14 @@ function Topbar() {
     const airdropIfNeeded = async () => {
       if (validator.status !== NetStatus.Running) return;
       let lamportAmount = 0;
-      let airdropThreshold = 0;
+
+      // arbitrary -- want to let people top up
+      // on devnet SOL when they can
+      let airdropThreshold = 50;
       switch (net) {
         case Net.Dev:
           // limit per devnet aidrop request
           lamportAmount = 2;
-          // arbitrary -- want to let people top up
-          // on devnet SOL when they can
-          airdropThreshold = 50;
           break;
         case Net.Test:
           // limit per testnet airdrop request

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -13,7 +13,7 @@ import {
 import '@solana/wallet-adapter-react-ui/styles.css';
 import * as sol from '@solana/web3.js';
 import isElectron from 'is-electron';
-import React, { FC, useEffect, useMemo, useState } from 'react';
+import { FC, useEffect, useMemo, useState } from 'react';
 import { Button, Form } from 'react-bootstrap';
 import Container from 'react-bootstrap/Container';
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -167,7 +167,7 @@ function Topbar() {
       }
     };
     airdropIfNeeded();
-  }, [net, wallet, validator]);
+  }, [net, wallet.publicKey, validator]);
 
   return (
     <div className="flex items-center p-1 px-2 bg-surface-400">


### PR DESCRIPTION
Closes #59 
Closes #222 

Going to hold off on saying #181 is resolved, because I couldn't figure out a way to get the adapter to go ahead and automatically use the electron storage one. Do you know any way? 

Doesn't cover config item to not do this, how bad do you want that in 0.4.0?