### PR TITLE
Don't re-render changes row if we don't get an initialised changes struct, and make cache big enough for main-net

### DIFF
--- a/src/renderer/components/ProgramChange.tsx
+++ b/src/renderer/components/ProgramChange.tsx
@@ -34,16 +34,20 @@ export function ProgramChange(props: {
       return;
     }
     if (!pubKey) {
-      setChangeInfo(undefined);
+      // setChangeInfo(undefined);
       return;
     }
-    setChangeInfo(getAccount(net, pubKey));
+    const update = getAccount(net, pubKey);
+    if (!update) {
+      return;
+    }
+    setChangeInfo(update);
   }, [net, status, pubKey]);
   useEffect(updateAccount, [updateAccount]);
   useInterval(updateAccount, 666);
 
   if (!change) {
-    return;
+    return null;
   }
 
   const showCount = change?.count || 0;

--- a/src/renderer/components/ProgramChange.tsx
+++ b/src/renderer/components/ProgramChange.tsx
@@ -42,6 +42,10 @@ export function ProgramChange(props: {
   useEffect(updateAccount, [updateAccount]);
   useInterval(updateAccount, 666);
 
+  if (!change) {
+    return;
+  }
+
   const showCount = change?.count || 0;
   const showSOL = change
     ? truncateLamportAmount(change)

--- a/src/renderer/components/ProgramChangeView.tsx
+++ b/src/renderer/components/ProgramChangeView.tsx
@@ -98,18 +98,32 @@ function ProgramChangeView() {
   const WalletAdapterState = useWallet();
 
   function sortFunction(a: AccountInfo, b: AccountInfo) {
+    let order = 0;
     switch (sortColumn) {
       case SortColumn.Count:
-        return b.count - a.count;
+        order = b.count - a.count;
+        break;
       case SortColumn.Sol:
         if (!b.accountInfo || !a.accountInfo) {
-          return 0;
+          order = 0;
+        } else {
+          order = b.accountInfo.lamports - a.accountInfo.lamports;
         }
-        return b.accountInfo.lamports - a.accountInfo.lamports;
+        break;
       case SortColumn.MaxDelta:
       default:
-        return Math.abs(b.maxDelta) - Math.abs(a.maxDelta);
+        order = Math.abs(b.maxDelta) - Math.abs(a.maxDelta);
     }
+
+    if (order === 0) {
+      // tie breaker based on public key
+      if (a.pubKey > b.pubKey) {
+        return 1;
+      }
+
+      return -1;
+    }
+    return order;
   }
 
   useInterval(() => {

--- a/src/renderer/components/ProgramChangeView.tsx
+++ b/src/renderer/components/ProgramChangeView.tsx
@@ -159,8 +159,14 @@ function ProgramChangeView() {
     });
     setPinnedAccount(pinMap);
     setDisplayList(showKeys);
-    refreshAccountInfos(net, showKeys);
-  }, 666);
+  }, 333);
+
+  useInterval(() => {
+    if (status !== NetStatus.Running) {
+      return;
+    }
+    refreshAccountInfos(net, displayList);
+  }, 2222);
 
   const uniqueAccounts = displayList.length;
 

--- a/src/renderer/data/accounts/getAccount.ts
+++ b/src/renderer/data/accounts/getAccount.ts
@@ -18,7 +18,7 @@ const HEXDUMP_BYTES = 512;
 //       Also use that to decide if we need to do a validator is available check or not - if we're watching changes, then we already know...
 
 const cache = new LRUCache<string, AccountInfo>({
-  maxSize: 500,
+  maxSize: 2000,
   entryExpirationTimeInMS: 60000,
 });
 
@@ -109,7 +109,6 @@ export function getAccount(net: Net, pubKey: string): AccountInfo | undefined {
   if (cachedResponse) {
     return cachedResponse;
   }
-
   // logger.silly('getAccountInfo cache miss', pubKey, pubKey.toString());
 
   const response: AccountInfo = {

--- a/src/renderer/nav/ValidatorNetworkInfo.tsx
+++ b/src/renderer/nav/ValidatorNetworkInfo.tsx
@@ -2,7 +2,6 @@ import * as sol from '@solana/web3.js';
 import { useEffect, useState } from 'react';
 import { Col, Row } from 'react-bootstrap';
 import Container from 'react-bootstrap/Container';
-import { isWhiteSpaceLike } from 'typescript';
 import { VictoryPie } from 'victory';
 import { logger } from '../common/globals';
 import {


### PR DESCRIPTION
 - but mainnet shows there's more

closes #259
closes #225
closes #239

Signed-off-by: Sven Dowideit <SvenDowideit@home.org.au>