### PR TITLE
Add missing .pre class

### DIFF
--- a/src/renderer/App.scss
+++ b/src/renderer/App.scss
@@ -33,5 +33,9 @@
     color: black;
 }
 
+div.pre {
+    font-family: "Space Mono", monospace;
+}
+
 // Import all of bootstrap, this isn't an exercise in minimisation
 // @import "bootstrap/scss/bootstrap";


### PR DESCRIPTION
Closes https://github.com/workbenchapp/solana-workbench/issues/267 

For reasons I'm not clear on, we use `div.pre` instead of `<code>` tag. Changing `<InlineKey>`
directly had other styling issues, so this will do for a hotfix for now.

Signed-off-by: Nathan LeClaire <nathan@cryptoworkbench.io>