### PR TITLE
use a global to set the Commitment level, and set it to `processed' so getAccount* calls are fast.

### DIFF
--- a/src/renderer/common/globals.ts
+++ b/src/renderer/common/globals.ts
@@ -2,3 +2,9 @@
 export const logger = (() => {
   return window.electron?.log;
 })();
+
+// TODO: make this selectable - Return information at the selected commitment level
+//      [possible values: processed, confirmed, finalized]
+//      cli default seems to be finalized
+// The _get_ data commitment level - can cause mutation API calls to fail (i think due to wallet-adapter things)
+export const commitmentLevel = 'processed';

--- a/src/renderer/components/LogView.tsx
+++ b/src/renderer/components/LogView.tsx
@@ -1,6 +1,6 @@
 import * as sol from '@solana/web3.js';
 import { useEffect, useState } from 'react';
-import { logger } from '../common/globals';
+import { logger, commitmentLevel } from '../common/globals';
 import {
   NetStatus,
   netToURL,
@@ -14,12 +14,6 @@ export interface LogSubscriptionMap {
     solConn: sol.Connection;
   };
 }
-
-// TODO: make this selectable - Return information at the selected commitment level
-//      [possible values: processed, confirmed, finalized]
-//      cli default seems to be finalized
-
-const commitmentLevel = 'processed';
 
 const logSubscriptions: LogSubscriptionMap = {};
 

--- a/src/renderer/components/tokens/CreateNewMintButton.tsx
+++ b/src/renderer/components/tokens/CreateNewMintButton.tsx
@@ -31,6 +31,7 @@ async function createNewMint(
   //   0 // Location of the decimal place
   // );
   const confirmOptions: sol.ConfirmOptions = {
+    // using the global commitmentLevel = 'processed' causes this to error out
     commitment: 'finalized',
   };
   // eslint-disable-next-line promise/no-nesting
@@ -118,7 +119,13 @@ function CreateNewMintButton(props: {
               error: `Create mint account failed 🤯`,
             }
           )
-          .then(() => {
+          .then(async () => {
+            function delay(milliseconds: number) {
+              return new Promise((resolve) =>
+                setTimeout(resolve, milliseconds)
+              );
+            }
+            await delay(1000);
             // TODO: SVEN - this one doesn't help.
             queryClient.invalidateQueries(); // TODO: mutate() anyone?
             return true;

--- a/src/renderer/components/tokens/MetaplexTokenData.tsx
+++ b/src/renderer/components/tokens/MetaplexTokenData.tsx
@@ -9,7 +9,7 @@ import { useConnection, useWallet } from '@solana/wallet-adapter-react';
 import * as metaplex from '@metaplex/js';
 import * as sol from '@solana/web3.js';
 
-import { useQuery } from 'react-query';
+import { useQuery, useQueryClient } from 'react-query';
 import { queryTokenMetadata } from '../../data/accounts/getAccount';
 import { useAppSelector } from '../../hooks';
 
@@ -25,6 +25,7 @@ function DataPopover(props: { mintPubKey: sol.PublicKey }) {
   const selectedWallet = useWallet();
   const { connection } = useConnection();
   const { net } = useAppSelector(selectValidatorNetworkState);
+  const queryClient = useQueryClient();
 
   const pubKey = mintPubKey.toString();
   const {
@@ -180,18 +181,31 @@ function DataPopover(props: { mintPubKey: sol.PublicKey }) {
                 type="button"
                 onClick={() => {
                   document.body.click();
-                  toast.promise(createOurMintMetadata(), {
-                    pending: 'Add mint metadata submitted',
-                    success: 'Add mint metadata succeeded 👌',
-                    error: {
-                      render({ data }) {
-                        // eslint-disable-next-line no-console
-                        console.log('error', data);
-                        // When the promise reject, data will contains the error
-                        return 'Error modifying mint metadata';
+                  toast
+                    .promise(createOurMintMetadata(), {
+                      pending: 'Add mint metadata submitted',
+                      success: 'Add mint metadata succeeded 👌',
+                      error: {
+                        render({ data }) {
+                          // eslint-disable-next-line no-console
+                          console.log('error', data);
+                          // When the promise reject, data will contains the error
+                          return 'Error modifying mint metadata';
+                        },
                       },
-                    },
-                  });
+                    })
+                    .then(async () => {
+                      function delay(milliseconds: number) {
+                        return new Promise((resolve) =>
+                          setTimeout(resolve, milliseconds)
+                        );
+                      }
+                      await delay(1000);
+                      // TODO: SVEN - this one doesn't help.
+                      queryClient.invalidateQueries(); // TODO: mutate() anyone?
+                      return true;
+                    })
+                    .catch(logger.error);
                 }}
               >
                 Submit

--- a/src/renderer/data/accounts/account.ts
+++ b/src/renderer/data/accounts/account.ts
@@ -1,7 +1,7 @@
 import { AnyAction, Dispatch, ThunkDispatch } from '@reduxjs/toolkit';
 import { WalletContextState } from '@solana/wallet-adapter-react';
 import * as sol from '@solana/web3.js';
-import { logger } from '../../common/globals';
+import { logger, commitmentLevel } from '../../common/globals';
 import { NewKeyPairInfo } from '../../../types/types';
 import { ConfigState, setConfigValue } from '../Config/configState';
 import { SelectedAccountsList } from '../SelectedAccountsList/selectedAccountsState';
@@ -57,7 +57,7 @@ export async function sendSolFromSelectedWallet(
 
   signature = await sendTransaction(transaction, connection);
 
-  await connection.confirmTransaction(signature, 'finalized');
+  await connection.confirmTransaction(signature, commitmentLevel);
 }
 
 async function createNewAccount(

--- a/src/renderer/data/accounts/getAccount.ts
+++ b/src/renderer/data/accounts/getAccount.ts
@@ -4,7 +4,7 @@ import * as metaplex from '@metaplex/js';
 
 import { LRUCache } from 'typescript-lru-cache';
 import { useQuery } from 'react-query';
-import { logger } from '../../common/globals';
+import { logger, commitmentLevel } from '../../common/globals';
 import { Net, netToURL } from '../ValidatorNetwork/validatorNetworkState';
 import { AccountInfo } from './accountInfo';
 import { AccountMetaValues } from './accountState';
@@ -41,7 +41,7 @@ export async function getParsedAccount(
   net: Net,
   pubKey: string
 ): Promise<sol.AccountInfo<sol.ParsedAccountData> | undefined> {
-  const solConn = new sol.Connection(netToURL(net));
+  const solConn = new sol.Connection(netToURL(net), commitmentLevel);
 
   const key = new sol.PublicKey(pubKey);
 
@@ -141,7 +141,7 @@ export async function getTokenAccounts(
   net: Net,
   pubKey: string
 ): Promise<sol.RpcResponseAndContext<TokenAccountArray>> {
-  const solConn = new sol.Connection(netToURL(net));
+  const solConn = new sol.Connection(netToURL(net), commitmentLevel);
   const key = new sol.PublicKey(pubKey);
   const filter: sol.TokenAccountsFilter = {
     programId: new sol.PublicKey('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'),
@@ -176,7 +176,7 @@ export async function getTokenMetadata(
   net: Net,
   tokenPublicKey: string
 ): Promise<metaplex.programs.metadata.Metadata> {
-  const conn = new metaplex.Connection(netToURL(net), 'finalized');
+  const conn = new metaplex.Connection(netToURL(net), commitmentLevel);
   try {
     // TODO: this console.logs "metadata load Error: Unable to find account: HKCjVqNU35H3zsXAVetgo743qCDMu7ssGnET1yvN4RSJ"
     const meta = await metaplex.programs.metadata.Metadata.findByMint(
@@ -265,7 +265,7 @@ export const getHumanName = (meta: AccountMetaValues | undefined) => {
 };
 
 export async function refreshAccountInfos(net: Net, keys: string[]) {
-  const solConn = new sol.Connection(netToURL(net));
+  const solConn = new sol.Connection(netToURL(net), commitmentLevel);
   const pubKeys = keys.map((k) => new sol.PublicKey(k));
   const accountInfos = await solConn.getMultipleAccountsInfo(pubKeys);
 

--- a/src/renderer/wallet-adapter/electronAppStorage.ts
+++ b/src/renderer/wallet-adapter/electronAppStorage.ts
@@ -22,6 +22,7 @@ import {
   netToURL,
   globalNetworkSet,
 } from '../data/ValidatorNetwork/validatorNetworkState';
+import { commitmentLevel } from '../common/globals';
 
 interface ElectronAppStorageWallet {
   isElectronAppStorage?: boolean;
@@ -242,7 +243,7 @@ export class ElectronAppStorageWalletAdapter extends BaseMessageSignerWalletAdap
           transaction.feePayer || this.publicKey || undefined;
         transaction.recentBlockhash =
           transaction.recentBlockhash ||
-          (await connection.getRecentBlockhash('finalized')).blockhash;
+          (await connection.getRecentBlockhash(commitmentLevel)).blockhash;
 
         const { signature } = await wallet.signAndSendTransaction(
           transaction,

--- a/src/renderer/wallet-adapter/localstorage.ts
+++ b/src/renderer/wallet-adapter/localstorage.ts
@@ -19,6 +19,7 @@ import {
 import * as sol from '@solana/web3.js';
 import * as bip39 from 'bip39';
 import { saveState, loadState } from '../data/localstorage';
+import { commitmentLevel } from '../common/globals';
 
 interface LocalStorageWallet {
   isLocalStorage?: boolean;
@@ -252,7 +253,7 @@ export class LocalStorageWalletAdapter extends BaseMessageSignerWalletAdapter {
           transaction.feePayer || this.publicKey || undefined;
         transaction.recentBlockhash =
           transaction.recentBlockhash ||
-          (await connection.getRecentBlockhash('finalized')).blockhash;
+          (await connection.getRecentBlockhash(commitmentLevel)).blockhash;
 
         const { signature } = await wallet.signAndSendTransaction(
           transaction,


### PR DESCRIPTION
and then add a delay in the toasts to trigger the get data from the API update so that the validator gives us the updated info (I'm sure its too long - tuning it later

Signed-off-by: Sven Dowideit <SvenDowideit@home.org.au>